### PR TITLE
piggy-markl + piggy-ids + piggy-box: accept age_x25519_pub recipients

### DIFF
--- a/crates/piggy-box/src/error.rs
+++ b/crates/piggy-box/src/error.rs
@@ -20,6 +20,14 @@ pub enum BoxError {
     #[error("unsupported curve: {0}")]
     UnsupportedCurve(String),
 
+    /// A markl recipient ID parsed cleanly (correct purpose, known
+    /// format) but the encrypt pipeline does not yet know how to wrap
+    /// the recovery share for that format. Currently the only format
+    /// in this state is `age_x25519_pub`, pending the RFC 0004
+    /// wire-format extension (piggy-box `AgeBox` part type).
+    #[error("recipient format not yet wired into the encrypt pipeline: {0}")]
+    UnsupportedRecipientFormat(String),
+
     #[error("crypto: {0}")]
     Crypto(String),
 

--- a/crates/piggy-box/src/lib.rs
+++ b/crates/piggy-box/src/lib.rs
@@ -12,7 +12,9 @@ pub mod wire;
 pub use ebox::{Ebox, EboxConfig, EboxPart, EboxType};
 pub use error::BoxError;
 pub use piv_box::PivBox;
-pub use recipients::{template_from_recipients, tpl_part_from_markl};
+pub use recipients::{
+    age_part_from_markl, piv_part_from_markl, template_from_recipients, tpl_part_from_markl,
+};
 pub use stream::EboxStream;
 pub use template::EboxConfigType;
 pub use template::{EboxTemplate, EboxTplConfig, EboxTplPart};

--- a/crates/piggy-box/src/recipients.rs
+++ b/crates/piggy-box/src/recipients.rs
@@ -1,10 +1,22 @@
 //! Markl ID → ebox template plumbing.
 //!
 //! Bridges `piggy_markl::Id` (the piggy 2.x recipient identifier) and
-//! piggy-box's [`EboxTplPart`] / [`EboxTemplate`] shapes. The
-//! conversion produces guid-less template parts, which the patched
-//! pivy parser (#70) accepts and the runtime resolves by pubkey
-//! alone.
+//! piggy-box's [`EboxTplPart`] / [`EboxTemplate`] shapes.
+//!
+//! The piggy 2.x recipient purpose (`piggy-recipient-v1`) accepts two
+//! markl formats:
+//!
+//! * `pivy_ecdh_p256_pub` — PIV ECDH P-256 recipient. Maps directly
+//!   onto today's [`EboxTplPart`]; the produced template is a v1
+//!   ebox that decrypts via the existing PIV path.
+//! * `age_x25519_pub` — age v1 X25519 recipient. Accepted at the
+//!   markl/`piggy-ids` layer so files declaring age recipients
+//!   parse cleanly, but the encrypt pipeline does **not** yet
+//!   produce ebox files for age parts — that lands with the RFC
+//!   0004 wire-format extension (`AgeBox` part variant, ebox v2).
+//!   Attempting `template_from_recipients` on an age markl ID today
+//!   returns [`BoxError::UnsupportedRecipientFormat`] with a pointer
+//!   to RFC 0004.
 //!
 //! This module is the load-bearing piece of phase 3's tracer-bullet
 //! (#73): once `recipients_to_template` works end-to-end (Rust
@@ -17,10 +29,32 @@ use crate::error::{BoxError, Result};
 use crate::piv_box::EcCurve;
 use crate::template::{EboxConfigType, EboxTemplate, EboxTplConfig, EboxTplPart, DEFAULT_SLOT};
 
-/// Build a piggy 2.x recipient template part from a markl ID. The
-/// produced part is guid-less; piggy-box's writer (after the
-/// guid-optional change in this commit) skips emitting the GUID tag.
+/// Build a piggy 2.x recipient template part from a markl ID. Routes
+/// on the markl format:
+///
+/// * [`FormatId::PivyEcdhP256Pub`] → [`piv_part_from_markl`]
+/// * [`FormatId::AgeX25519Pub`]    → [`age_part_from_markl`] (currently
+///   returns [`BoxError::UnsupportedRecipientFormat`])
+///
+/// Any other format is rejected as a wire-level error. The produced
+/// part (when a part is produced) is guid-less; piggy-box's writer
+/// skips emitting the GUID tag.
 pub fn tpl_part_from_markl(id: &MarklId) -> Result<EboxTplPart> {
+    match id.format() {
+        FormatId::PivyEcdhP256Pub => piv_part_from_markl(id),
+        FormatId::AgeX25519Pub => age_part_from_markl(id),
+        other => Err(BoxError::Wire(format!(
+            "unsupported recipient format: {other:?} \
+             (piggy-recipient-v1 accepts pivy_ecdh_p256_pub or age_x25519_pub)"
+        ))),
+    }
+}
+
+/// Build an [`EboxTplPart`] from a `pivy_ecdh_p256_pub` markl ID.
+/// Validates the purpose constraint (must be
+/// [`PurposeId::PiggyRecipientV1`] or bare) and produces a guid-less
+/// part on the NIST P-256 curve.
+pub fn piv_part_from_markl(id: &MarklId) -> Result<EboxTplPart> {
     if id.format() != FormatId::PivyEcdhP256Pub {
         return Err(BoxError::Wire(format!(
             "expected pivy_ecdh_p256_pub format, got {:?}",
@@ -42,6 +76,48 @@ pub fn tpl_part_from_markl(id: &MarklId) -> Result<EboxTplPart> {
         pubkey_curve: EcCurve::NistP256,
         cak: None,
     })
+}
+
+/// Build an [`EboxTplPart`] from an `age_x25519_pub` markl ID.
+///
+/// Currently returns [`BoxError::UnsupportedRecipientFormat`]: the
+/// markl/`piggy-ids` layers accept age recipients so files validate,
+/// canonicalize, and diff cleanly, but the piggy-box encrypt pipeline
+/// has no `AgeBox` part variant yet. The RFC 0004 wire-format
+/// extension introduces:
+///   * A part-kind discriminator on [`EboxTplPart`] (piv vs age).
+///   * An `AgeBox` per-recipient share-wrap analogous to [`PivBox`],
+///     produced and consumed via the `age` crate so plugin
+///     identities (e.g. `age-plugin-yubikey`) work transparently
+///     at decrypt time.
+///   * An ebox wire-format version bump (v1 → v2); v1 files keep
+///     working at decrypt time forever.
+///
+/// Validates the purpose / format invariants here so the error path
+/// surfaces a meaningful "format not yet wired" message rather than a
+/// generic "expected X, got Y" — callers see exactly why the wire
+/// path isn't open.
+pub fn age_part_from_markl(id: &MarklId) -> Result<EboxTplPart> {
+    if id.format() != FormatId::AgeX25519Pub {
+        return Err(BoxError::Wire(format!(
+            "expected age_x25519_pub format, got {:?}",
+            id.format()
+        )));
+    }
+    if !matches!(id.purpose(), None | Some(PurposeId::PiggyRecipientV1)) {
+        return Err(BoxError::Wire(format!(
+            "expected piggy-recipient-v1 purpose (or none), got {:?}",
+            id.purpose()
+        )));
+    }
+    Err(BoxError::UnsupportedRecipientFormat(
+        "age_x25519_pub — wire-format integration pending piggy RFC 0004 \
+         (AgeBox part variant, ebox v2). Markl-level validation accepts \
+         this recipient, but the encrypt pipeline cannot yet wrap a share \
+         for it. Use a pivy_ecdh_p256_pub recipient until the wire-format \
+         extension lands."
+            .into(),
+    ))
 }
 
 /// Build an `EboxTemplate` whose single Primary config requires
@@ -83,6 +159,18 @@ mod tests {
             .public_key()
             .to_bytes(&group, PointConversionForm::COMPRESSED, &mut ctx)
             .unwrap()
+    }
+
+    /// Build a 32-byte placeholder X25519 pubkey for markl-level tests.
+    /// X25519 has no on-curve bit-pattern constraints; any 32 bytes
+    /// parse as a valid markl `age_x25519_pub` payload. The markl
+    /// layer doesn't perform curve validation — that's age's job at
+    /// stanza wrap time.
+    fn placeholder_age_pubkey_bytes() -> Vec<u8> {
+        // Use a fixed, recognizable pattern so test failures point
+        // back here, and so a stray prompt with these bytes in it
+        // is obviously a test fixture.
+        (0u8..32).collect()
     }
 
     #[test]
@@ -160,5 +248,78 @@ mod tests {
         let parsed = EboxTemplate::from_bytes(&bytes).unwrap();
         assert!(parsed.configs[0].parts[0].guid.is_none());
         assert_eq!(parsed.configs[0].parts[0].pubkey, pk);
+    }
+
+    /// Age recipients pass markl validation (purpose `piggy-recipient-v1`
+    /// accepts `age_x25519_pub` since the RFC 0003 §4.2 broadening), so
+    /// `Id::new` returns Ok. The encrypt pipeline, however, has no
+    /// AgeBox part variant yet — `tpl_part_from_markl` must surface
+    /// that gap as `UnsupportedRecipientFormat`, not as a generic wire
+    /// error, so callers (piggy-ids encrypt, future bash dispatch) can
+    /// produce a directed user-facing message.
+    #[test]
+    fn age_recipient_markl_id_parses_but_encrypt_pipeline_refuses() {
+        let pk = placeholder_age_pubkey_bytes();
+        let id = Id::new(
+            Some(PurposeId::PiggyRecipientV1),
+            FormatId::AgeX25519Pub,
+            pk,
+        )
+        .expect("piggy-recipient-v1@age_x25519_pub must pass markl validation \
+                 after the RFC 0003 §4.2 broadening");
+        let err = tpl_part_from_markl(&id).unwrap_err();
+        assert!(
+            matches!(err, BoxError::UnsupportedRecipientFormat(_)),
+            "age recipients should fail with UnsupportedRecipientFormat \
+             (pointing at RFC 0004), not a generic Wire error; got {err:?}",
+        );
+    }
+
+    /// A mixed `piggy-ids` (one pivy recipient + one age recipient)
+    /// today fails fast on the first age part because the encrypt
+    /// pipeline isn't extended yet. Once RFC 0004 lands, this test
+    /// should be promoted to a positive case asserting both parts
+    /// appear in the produced template (and the resulting ebox v2 is
+    /// decryptable by either identity).
+    #[test]
+    fn template_with_mixed_recipients_fails_until_rfc_0004_lands() {
+        let piv_id = Id::new(
+            Some(PurposeId::PiggyRecipientV1),
+            FormatId::PivyEcdhP256Pub,
+            fresh_p256_pubkey_bytes(),
+        )
+        .unwrap();
+        let age_id = Id::new(
+            Some(PurposeId::PiggyRecipientV1),
+            FormatId::AgeX25519Pub,
+            placeholder_age_pubkey_bytes(),
+        )
+        .unwrap();
+        let err = template_from_recipients(&[piv_id, age_id]).unwrap_err();
+        assert!(matches!(err, BoxError::UnsupportedRecipientFormat(_)));
+    }
+
+    #[test]
+    fn piv_part_from_markl_rejects_wrong_format() {
+        let id = Id::new(
+            Some(PurposeId::PiggyRecipientV1),
+            FormatId::AgeX25519Pub,
+            placeholder_age_pubkey_bytes(),
+        )
+        .unwrap();
+        let err = piv_part_from_markl(&id).unwrap_err();
+        assert!(matches!(err, BoxError::Wire(_)));
+    }
+
+    #[test]
+    fn age_part_from_markl_rejects_wrong_format() {
+        let id = Id::new(
+            Some(PurposeId::PiggyRecipientV1),
+            FormatId::PivyEcdhP256Pub,
+            fresh_p256_pubkey_bytes(),
+        )
+        .unwrap();
+        let err = age_part_from_markl(&id).unwrap_err();
+        assert!(matches!(err, BoxError::Wire(_)));
     }
 }

--- a/crates/piggy-ids/src/lib.rs
+++ b/crates/piggy-ids/src/lib.rs
@@ -7,13 +7,22 @@
 //! # comments and blank lines ignored
 //! piggy-recipient-v1@pivy_ecdh_p256_pub-<blech32>  # primary yubikey
 //! piggy-recipient-v1@pivy_ecdh_p256_pub-<blech32>  # backup
+//! piggy-recipient-v1@age_x25519_pub-<blech32>      # age identity (laptop)
 //! ```
 //!
+//! Two recipient formats are accepted under the `piggy-recipient-v1`
+//! purpose: `pivy_ecdh_p256_pub` (PIV 9D, ECDH P-256) and
+//! `age_x25519_pub` (age v1 X25519). Files may mix the two families
+//! freely. Encrypt-pipeline support for producing ebox files with
+//! age parts ships under piggy RFC 0004; markl-level parsing,
+//! validation, canonicalisation, and diffing accept age recipients
+//! today regardless of pipeline readiness.
+//!
 //! Parser is permissive about purpose tagging on input — bare
-//! `pivy_ecdh_p256_pub-<blech32>` is accepted as syntactic sugar for
-//! the purpose-tagged form. Renderer always emits the purpose-tagged
-//! canonical form so `parse → render → parse` round-trips to a stable
-//! representation.
+//! `<format>-<blech32>` is accepted as syntactic sugar for the
+//! purpose-tagged form for either format family. Renderer always
+//! emits the purpose-tagged canonical form so `parse → render →
+//! parse` round-trips to a stable representation.
 
 use thiserror::Error;
 
@@ -35,8 +44,9 @@ pub struct Recipient {
 
 impl Recipient {
     /// Construct a recipient. The id MUST carry the
-    /// `piggy-recipient-v1` purpose and the `pivy_ecdh_p256_pub`
-    /// format; otherwise `InvalidRecipientShape` is returned.
+    /// `piggy-recipient-v1` purpose and one of the recipient formats
+    /// (`pivy_ecdh_p256_pub` or `age_x25519_pub`); otherwise
+    /// `InvalidRecipientShape` is returned.
     pub fn new(id: Id, comment: Option<String>) -> Result<Self, ParseError> {
         validate_recipient_shape(&id)?;
         Ok(Self { id, comment })
@@ -191,7 +201,8 @@ pub enum ParseError {
     },
     #[error(
         "line {line}: recipient shape requires purpose=piggy-recipient-v1 and \
-         format=pivy_ecdh_p256_pub (got purpose={purpose:?}, format={format:?})"
+         format in {{pivy_ecdh_p256_pub, age_x25519_pub}} \
+         (got purpose={purpose:?}, format={format:?})"
     )]
     InvalidRecipientShape {
         line: usize,
@@ -202,9 +213,21 @@ pub enum ParseError {
     EmptyToken { line: usize },
 }
 
+/// The set of markl formats accepted as `piggy-recipient-v1`
+/// recipients. Kept as a single source of truth so the parser, the
+/// `Recipient::new` validator, and downstream tooling stay in sync as
+/// the recipient family grows (today: pivy + age; future: whatever
+/// RFC 0004 follow-ups add).
+fn is_recipient_format(format: FormatId) -> bool {
+    matches!(
+        format,
+        FormatId::PivyEcdhP256Pub | FormatId::AgeX25519Pub
+    )
+}
+
 fn validate_recipient_shape(id: &Id) -> Result<(), ParseError> {
     let purpose_ok = matches!(id.purpose(), Some(PurposeId::PiggyRecipientV1));
-    let format_ok = matches!(id.format(), FormatId::PivyEcdhP256Pub);
+    let format_ok = is_recipient_format(id.format());
     if purpose_ok && format_ok {
         Ok(())
     } else {
@@ -221,8 +244,9 @@ fn canonicalize_for_render(id: &Id) -> Id {
         id.clone()
     } else {
         // Bare markl ID (no purpose): promote to purpose-tagged form.
-        // Validated at parse-time that the format is
-        // pivy_ecdh_p256_pub, so re-construction can't fail.
+        // Validated at parse-time that the format is one accepted by
+        // `piggy-recipient-v1` (pivy_ecdh_p256_pub or age_x25519_pub),
+        // so re-construction can't fail.
         Id::new(
             Some(PurposeId::PiggyRecipientV1),
             id.format(),
@@ -270,7 +294,7 @@ fn parse_line(raw: &str, line_no: usize) -> Result<Recipient, ParseError> {
 
     // Validate purpose AND format. Permit bare format on input
     // (no purpose) — we'll canonicalise on render.
-    let format_ok = matches!(id.format(), FormatId::PivyEcdhP256Pub);
+    let format_ok = is_recipient_format(id.format());
     let purpose_ok = matches!(id.purpose(), None | Some(PurposeId::PiggyRecipientV1));
     if !(purpose_ok && format_ok) {
         return Err(ParseError::InvalidRecipientShape {
@@ -301,6 +325,20 @@ mod tests {
             Some(PurposeId::PiggyRecipientV1),
             FormatId::PivyEcdhP256Pub,
             sample_pubkey(seed),
+        )
+        .unwrap()
+    }
+
+    /// Build an age X25519 recipient markl ID. X25519 pubkeys are
+    /// 32 raw bytes (no on-curve prefix byte, unlike SEC1-compressed
+    /// EC points), and the markl layer doesn't curve-validate — so
+    /// any 32-byte payload yields a valid `age_x25519_pub` markl ID.
+    fn sample_age_id(seed: u8) -> Id {
+        let payload: Vec<u8> = (0..32u8).map(|i| i.wrapping_mul(seed)).collect();
+        Id::new(
+            Some(PurposeId::PiggyRecipientV1),
+            FormatId::AgeX25519Pub,
+            payload,
         )
         .unwrap()
     }
@@ -453,5 +491,72 @@ mod tests {
         let second = RecipientFile::parse(&rendered).unwrap();
         assert_eq!(second.recipients(), first.recipients());
         assert_eq!(second.render(), rendered);
+    }
+
+    #[test]
+    fn parse_accepts_age_recipient_with_purpose() {
+        // Per RFC 0003 §4.2 (broadened): a `piggy-recipient-v1@
+        // age_x25519_pub-…` markl ID must parse cleanly. Encrypt-
+        // pipeline support is gated on RFC 0004; markl-level
+        // validation/canonicalisation/diffing must not be.
+        let id = sample_age_id(11);
+        let input = format!("{}  # age-laptop\n", id.to_wire());
+        let file = RecipientFile::parse(&input).unwrap();
+        assert_eq!(file.recipients().len(), 1);
+        assert_eq!(file.recipients()[0].id(), &id);
+        assert_eq!(file.recipients()[0].comment(), Some("age-laptop"));
+    }
+
+    #[test]
+    fn parse_accepts_bare_age_format_and_canonicalises_to_purpose_tagged() {
+        // Mirror the existing pivy bare-format test for the age family.
+        let id = sample_age_id(13);
+        let bare = Id::new(None, FormatId::AgeX25519Pub, id.data().to_vec())
+            .unwrap()
+            .to_wire();
+        let input = format!("{bare}\n");
+        let file = RecipientFile::parse(&input).unwrap();
+        let rendered = file.render();
+        assert!(
+            rendered.starts_with("piggy-recipient-v1@age_x25519_pub-"),
+            "render must promote bare age recipient to purpose-tagged form, got: {rendered}",
+        );
+    }
+
+    #[test]
+    fn parse_accepts_mixed_pivy_and_age_recipients() {
+        let piv = sample_id(7);
+        let age = sample_age_id(11);
+        let input = format!(
+            "{}  # primary yubikey\n{}  # age laptop\n",
+            piv.to_wire(),
+            age.to_wire(),
+        );
+        let file = RecipientFile::parse(&input).unwrap();
+        assert_eq!(file.recipients().len(), 2);
+        assert_eq!(file.recipients()[0].id().format(), FormatId::PivyEcdhP256Pub);
+        assert_eq!(file.recipients()[1].id().format(), FormatId::AgeX25519Pub);
+    }
+
+    #[test]
+    fn age_recipient_idempotent_parse_render_parse() {
+        let piv = sample_id(23);
+        let age = sample_age_id(29);
+        let input = format!("{}  # piv\n{}  # age\n", piv.to_wire(), age.to_wire());
+        let first = RecipientFile::parse(&input).unwrap();
+        let rendered = first.render();
+        let second = RecipientFile::parse(&rendered).unwrap();
+        assert_eq!(second.recipients(), first.recipients());
+        assert_eq!(second.render(), rendered);
+    }
+
+    #[test]
+    fn recipient_new_accepts_age_format() {
+        // The `Recipient::new` constructor is a separate gate from the
+        // file parser — exercise it directly so a regression in
+        // `validate_recipient_shape` doesn't slip through.
+        let id = sample_age_id(17);
+        let r = Recipient::new(id.clone(), Some("age".into())).unwrap();
+        assert_eq!(r.id(), &id);
     }
 }

--- a/crates/piggy-markl/src/lib.rs
+++ b/crates/piggy-markl/src/lib.rs
@@ -14,10 +14,13 @@
 //! `go/internal/charlie/markl_registrations/testdata/0002-markl-id-format-vectors.json`.
 //! See amarbel-llc/piggy#71 for the umbrella tracker.
 //!
-//! Scope: piggy 2.x's recipient template (`pivy_ecdh_p256_pub` payloads
-//! tagged with the `piggy-recipient-v1` purpose). Other format IDs and
-//! purposes from the registry are scaffolded so unrecognised inputs
-//! fail cleanly rather than silently mismatching.
+//! Scope: piggy 2.x's recipient identifiers — two format families
+//! are accepted under the `piggy-recipient-v1` purpose:
+//! `pivy_ecdh_p256_pub` (33-byte SEC1 compressed P-256 point, PIV
+//! slot 9D) and `age_x25519_pub` (32-byte X25519 pubkey, age v1
+//! recipient; wire-format integration ships under piggy RFC 0004).
+//! Other format IDs and purposes from the registry are scaffolded so
+//! unrecognised inputs fail cleanly rather than silently mismatching.
 
 pub mod blech32;
 pub mod format;
@@ -56,6 +59,28 @@ mod proptest_round_trips {
             prop_assert_eq!(parsed.purpose(), Some(&PurposeId::PiggyRecipientV1));
             prop_assert_eq!(parsed.format(), FormatId::PivyEcdhP256Pub);
             prop_assert_eq!(parsed.data(), bytes.as_slice());
+        }
+
+        /// Parallel of `pivy_ecdh_p256_pub_round_trips` for the age
+        /// X25519 recipient format. X25519 pubkeys are 32 raw bytes
+        /// with no on-curve prefix (unlike SEC1 P-256), so we sample
+        /// the full 32-byte payload uniformly.
+        #[test]
+        fn age_x25519_pub_round_trips(
+            bytes in proptest::array::uniform32(any::<u8>()),
+        ) {
+            let payload = bytes.to_vec();
+            let id = Id::new(
+                Some(PurposeId::PiggyRecipientV1),
+                FormatId::AgeX25519Pub,
+                payload.clone(),
+            ).unwrap();
+            let wire = id.to_wire();
+            prop_assert!(wire.starts_with("piggy-recipient-v1@age_x25519_pub-"));
+            let parsed = Id::parse(&wire).unwrap();
+            prop_assert_eq!(parsed.purpose(), Some(&PurposeId::PiggyRecipientV1));
+            prop_assert_eq!(parsed.format(), FormatId::AgeX25519Pub);
+            prop_assert_eq!(parsed.data(), payload.as_slice());
         }
 
         /// Random ascii-charset perturbations of a valid encoded ID

--- a/crates/piggy-markl/src/purpose.rs
+++ b/crates/piggy-markl/src/purpose.rs
@@ -18,10 +18,16 @@ use crate::format::FormatId;
 /// `Incompatible` since piggy can't reason about them.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PurposeId {
-    /// `piggy-recipient-v1` — piggy 2.x recipient pubkey, constrained
-    /// to `pivy_ecdh_p256_pub`. **Reserved by piggy** in RFC 0002 §6.3
-    /// (drafted in piggy at madder#150). Until the official RFC lands
-    /// this is the de facto definition.
+    /// `piggy-recipient-v1` — piggy 2.x recipient pubkey. **Reserved
+    /// by piggy** in RFC 0002 §6.3 (drafted in piggy at madder#150).
+    /// Accepts two formats:
+    ///   * `pivy_ecdh_p256_pub` — PIV slot 9D (Key Management, ECDH
+    ///     over NIST P-256). The piggy 1.x → 2.x cutover format.
+    ///   * `age_x25519_pub` — age v1 X25519 recipient pubkey. Same
+    ///     purpose, different cryptographic family. Wire-format
+    ///     integration is in progress (see piggy RFC 0004); markl-level
+    ///     parsing already accepts age recipients so `piggy-ids` files
+    ///     declaring them validate cleanly.
     PiggyRecipientV1,
     /// `piggy-piv_auth-v1` — public key from PIV slot 9A (PIV
     /// Authentication). Constrained to `ssh_ecdsa_nistp256_pub` for now;
@@ -95,7 +101,10 @@ impl PurposeId {
     /// purposes it didn't enumerate.
     pub fn validate_format(&self, format: FormatId) -> Result<(), Incompatible> {
         let ok = match self {
-            PurposeId::PiggyRecipientV1 => matches!(format, FormatId::PivyEcdhP256Pub),
+            PurposeId::PiggyRecipientV1 => matches!(
+                format,
+                FormatId::PivyEcdhP256Pub | FormatId::AgeX25519Pub
+            ),
             PurposeId::PiggyPivAuthV1
             | PurposeId::PiggyPivSigV1
             | PurposeId::PiggyPivCardAuthV1 => {
@@ -163,9 +172,19 @@ mod tests {
     }
 
     #[test]
-    fn piggy_recipient_v1_accepts_only_pivy_ecdh_p256_pub() {
+    fn piggy_recipient_v1_accepts_pivy_and_age_recipient_formats() {
         let p = PurposeId::PiggyRecipientV1;
+        // The two accepted recipient formats: PIV ECDH P-256 (piggy 1.x
+        // cutover format) and age X25519 (cross-family extension; see
+        // piggy RFC 0004).
         assert!(p.validate_format(FormatId::PivyEcdhP256Pub).is_ok());
+        assert!(p.validate_format(FormatId::AgeX25519Pub).is_ok());
+        // age secret keys are identities, not recipients — must not
+        // round-trip through the recipient purpose.
+        assert!(
+            p.validate_format(FormatId::AgeX25519Sec).is_err(),
+            "PiggyRecipientV1 must reject age_x25519_sec — that's an identity, not a recipient"
+        );
         assert!(
             p.validate_format(FormatId::SshEcdsaNistp256Pub).is_err(),
             "PiggyRecipientV1 should reject the SSH format — that's for piggy-piv_* purposes"

--- a/docs/rfcs/0003-piggy-ids-file-format.md
+++ b/docs/rfcs/0003-piggy-ids-file-format.md
@@ -17,11 +17,21 @@ provenance: |
 
 This RFC specifies the `piggy-ids` text file format used by piggy 2.x
 to declare the recipient set for a password store. A `piggy-ids`
-file carries one recipient per line, each identified by a markl ID of
-format `pivy_ecdh_p256_pub` tagged with the piggy-owned purpose
-`piggy-recipient-v1`. The format is hand-editable, version-controlled,
-and round-trips cleanly through tooling so that
-config-as-code-driven recipient management is idempotent.
+file carries one recipient per line, each identified by a markl ID
+tagged with the piggy-owned purpose `piggy-recipient-v1`. Two
+recipient formats are accepted under that purpose:
+
+- `pivy_ecdh_p256_pub` — PIV slot 9D (Key Management, ECDH over NIST
+  P-256). The piggy 1.x → 2.x cutover format.
+- `age_x25519_pub` — age v1 X25519 recipient. Markl-level parsing
+  accepts these so `piggy-ids` files declaring age recipients
+  validate, canonicalise, and diff cleanly; encrypt-pipeline support
+  for producing ebox files with `AgeBox` parts ships under piggy
+  RFC 0004 (in progress).
+
+The format is hand-editable, version-controlled, and round-trips
+cleanly through tooling so that config-as-code-driven recipient
+management is idempotent.
 
 ## Status and Provenance
 
@@ -51,10 +61,21 @@ subtree, mirroring the placement rules `.pivy-id` enjoyed in piggy 1.x).
 It declares the set of recipient public keys that the entries below
 it are encrypted to.
 
-Each recipient is the public key of slot 9D (PIV Key Management,
-ECDH) on a PIV smart card, encoded as a markl ID per madder RFC 0002.
-The piggy-owned `piggy-recipient-v1` purpose constrains the format
-to `pivy_ecdh_p256_pub` (33 bytes, SEC 1 compressed-point form).
+Each recipient is encoded as a markl ID per madder RFC 0002. The
+piggy-owned `piggy-recipient-v1` purpose accepts two formats:
+
+- `pivy_ecdh_p256_pub` (33 bytes, SEC 1 compressed-point form) — the
+  public key of slot 9D (PIV Key Management, ECDH) on a PIV smart
+  card.
+- `age_x25519_pub` (32 bytes) — an age v1 X25519 recipient. The
+  payload bytes are the raw X25519 pubkey; the equivalent `age1…`
+  string from native age tooling and this markl form encode the same
+  32 bytes under two different envelopes (bech32 vs blech32). Files
+  containing only age recipients, or a mix of age and pivy
+  recipients, parse and validate at the markl layer today; the
+  encrypt pipeline gains an `AgeBox` part variant under piggy RFC
+  0004 (`crates/piggy-box::age_part_from_markl` currently surfaces a
+  `BoxError::UnsupportedRecipientFormat` for age inputs).
 
 ### Filename
 
@@ -87,10 +108,12 @@ blank-line     = *WSP LF
 comment-line   = *WSP "#" *VCHAR LF
 recipient-line = *WSP markl-id [comment-suffix] LF
 comment-suffix = 1*WSP "#" [WSP *VCHAR]
-markl-id       = piggy-purpose-tagged / bare-pivy-format
-piggy-purpose-tagged = "piggy-recipient-v1" "@" pivy-blech32
-bare-pivy-format     = pivy-blech32
+markl-id       = piggy-purpose-tagged / bare-format
+piggy-purpose-tagged = "piggy-recipient-v1" "@" recipient-blech32
+bare-format    = recipient-blech32
+recipient-blech32 = pivy-blech32 / age-blech32
 pivy-blech32   = "pivy_ecdh_p256_pub" "-" 1*charset
+age-blech32    = "age_x25519_pub"    "-" 1*charset
 charset        = %x71 / %x70 / ...   ; bech32 alphabet, see madder RFC 0002 §3.1
 ```
 
@@ -108,13 +131,24 @@ Notes:
 
 For every recipient line:
 
-- The markl ID's format MUST be `pivy_ecdh_p256_pub`.
+- The markl ID's format MUST be one of `pivy_ecdh_p256_pub` or
+  `age_x25519_pub`. Other formats MUST be rejected at the
+  markl/piggy-ids layer.
 - The markl ID's purpose, if present, MUST be `piggy-recipient-v1`.
   Bare-format markl IDs (no purpose) MUST be accepted as input
   syntactic sugar; writers MUST canonicalise them to the
   purpose-tagged form on rewrite.
-- Readers MUST reject recipient lines whose markl ID violates either
-  rule, with an error that names the offending line number.
+- A `piggy-ids` file MAY mix `pivy_ecdh_p256_pub` and
+  `age_x25519_pub` recipients in any order; the encrypt pipeline
+  produces a single ebox whose Primary config carries one part per
+  recipient, with `n=1` (any one recipient can decrypt). Producing
+  age parts requires piggy RFC 0004; until that lands the encrypt
+  pipeline raises `BoxError::UnsupportedRecipientFormat` on any age
+  recipient. Markl-level parsing, validation, canonicalisation, and
+  diffing remain available for age recipients regardless.
+- Readers MUST reject recipient lines whose markl ID violates the
+  format-or-purpose rule above, with an error that names the
+  offending line number.
 
 ### Equality
 
@@ -161,8 +195,9 @@ truly a no-op: the recipient set is unchanged, the on-disk
 
 ```
 # piggy-ids — recipients for ~/.local/share/piggy
-piggy-recipient-v1@pivy_ecdh_p256_pub-9ft3m74l5t2ppwjrvfg3wp380jqj2zfrm6zevxqx34sdethvey0s5vm9gd  # primary yubikey
-piggy-recipient-v1@pivy_ecdh_p256_pub-qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw7n8w8c0ydp7s8jtgqnxa  # backup
+piggy-recipient-v1@pivy_ecdh_p256_pub-9ft3m74l5t2ppwjrvfg3wp380jqj2zfrm6zevxqx34sdethvey0s5vm9gd  # primary yubikey (9D)
+piggy-recipient-v1@pivy_ecdh_p256_pub-qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw7n8w8c0ydp7s8jtgqnxa  # backup yubikey (9D)
+piggy-recipient-v1@age_x25519_pub-qqqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0jqr9fwqu     # age identity (laptop, RFC 0004)
 ```
 
 ## Security Considerations
@@ -186,8 +221,20 @@ piggy-recipient-v1@pivy_ecdh_p256_pub-qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw7n8w
 3. **Format-confusion across markl ID formats is prevented at parse
    time.** Per madder RFC 0002 §8.3, the `(purpose, format)` pair is
    validated. piggy's reader additionally rejects any markl ID whose
-   format is not `pivy_ecdh_p256_pub` or whose purpose is not
-   `piggy-recipient-v1` (or absent).
+   format is not one of `pivy_ecdh_p256_pub` or `age_x25519_pub`, or
+   whose purpose is not `piggy-recipient-v1` (or absent). The
+   `piggy-recipient-v1` purpose binds equally to both recipient
+   formats; the cryptographic family is determined entirely by the
+   markl `format` field, never by purpose-string inspection.
+
+4. **Mixing recipient families does not weaken individual shares.**
+   When `piggy-ids` lists both pivy and age recipients, the produced
+   ebox carries one independently-wrapped share per recipient in a
+   single Primary config with `n=1`. Compromise of one identity
+   (e.g. an exfiltrated age secret) exposes that secret's share but
+   does not affect the PIV-card-protected shares, and vice versa.
+   The threat model is identical to the all-pivy case: any one held
+   identity is sufficient and necessary to decrypt.
 
 ## Backwards Compatibility
 

--- a/docs/rfcs/0004-age-recipients.md
+++ b/docs/rfcs/0004-age-recipients.md
@@ -1,0 +1,271 @@
+---
+status: draft (piggy 2.x; companion to piggy#3 Rust parity roadmap)
+date: 2026-05-15
+provenance: |
+  Captures the wire-format extension that lets piggy 2.x encrypt to
+  age v1 X25519 recipients alongside PIV ECDH P-256 recipients. The
+  markl-format and `piggy-ids`-grammar pieces shipped first (RFC 0003
+  §4 broadening; piggy-markl `PiggyRecipientV1` accepts `AgeX25519Pub`
+  in addition to `PivyEcdhP256Pub`). This RFC pins the remaining
+  pieces: how an ebox carries age recipient parts, how
+  `piggy-ids encrypt`/`decrypt` route per format, and how
+  age-plugin-yubikey identities slot into the decrypt path.
+---
+
+# Age Recipients in Piggy (piggy normative, draft)
+
+## Abstract
+
+This RFC extends piggy's ebox container (RFC 0002) and `piggy-ids`
+recipient files (RFC 0003) to carry age v1 X25519 recipients
+alongside the existing PIV ECDH P-256 recipients. The user-facing
+shape is unchanged: a `piggy-ids` file lists markl IDs under the
+`piggy-recipient-v1` purpose, and `piggy pass`/`piggy box` operate
+on the same `.ebox` files. The internal change is a new per-recipient
+share-wrap variant — `AgeBox` — that sits next to the existing
+`PivBox` in the ebox template/part wire shape, and a Rust-side
+decrypt dispatcher (`piggy-ids decrypt`) that replaces the current
+shell-out to the C `pivy-box stream decrypt` so age parts can be
+unwrapped via the `age` crate (with plugin-identity support
+including `age-plugin-yubikey`).
+
+## Status and Provenance
+
+Draft. The user-facing surface (markl parsing, `piggy-ids` file
+grammar) shipped under the "age recipient surface" change that
+landed alongside this RFC; the wire-format and decrypt-dispatcher
+pieces below are the remaining work.
+
+Until the wire format lands, `piggy-box::age_part_from_markl`
+returns `BoxError::UnsupportedRecipientFormat` and points callers
+at this document.
+
+## Requirements Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in RFC 2119.
+
+## Specification
+
+### Recipient Identifiers
+
+Per RFC 0003 §4.2 (broadened), the `piggy-recipient-v1` purpose
+accepts two markl formats:
+
+| Format               | Size (bytes) | Recipient family            |
+|----------------------|--------------|-----------------------------|
+| `pivy_ecdh_p256_pub` | 33           | PIV slot 9D (ECDH P-256)    |
+| `age_x25519_pub`     | 32           | age v1 X25519 recipient     |
+
+The 32-byte `age_x25519_pub` payload is the raw X25519 public key
+(the same 32 bytes that the upstream `age1…` bech32 string encodes;
+the two formats differ only in the surrounding envelope).
+
+### Ebox Wire-Format Extension (v2)
+
+The current ebox stream wire format (RFC 0002 §5) carries one
+`PivBox` per recipient inside each template part. To carry age
+recipients, an ebox v2 introduces a part-kind discriminator before
+the box payload:
+
+```text
+part = TAG_PART_KIND u8(kind) <kind-specific payload>
+kind = 0x01 (PivBox, today's payload)
+     | 0x02 (AgeBox)
+```
+
+- v2 readers MUST accept v1 streams unchanged (every v1 part is
+  treated as `kind=0x01`).
+- v1 readers (notably the C `pivy-box`) reject v2 streams with an
+  unknown-version error; this is acceptable because `piggy box` is
+  reserved for template/key administration, not stream crypto, after
+  this change. The Rust-side decrypt dispatcher
+  (`piggy-ids decrypt`) is the only piece that must understand v2.
+
+### `AgeBox` Payload
+
+An `AgeBox` part carries:
+
+- `recipient_pubkey` — the 32-byte X25519 pubkey (mirrors the markl
+  `data()` payload), kept inline so a future tool can identify
+  candidate identities without consulting the template separately.
+- `stanza_bytes` — the byte-encoded age stanza(s) wrapping the
+  recovery share for this single recipient, as produced by
+  `age::Encryptor::with_recipients` over a one-recipient
+  encryptor whose payload is the share bytes. Decoding hands the
+  same bytes to `age::Decryptor` along with the configured identity
+  set.
+
+This delegates all cryptographic decisions (KDF, AEAD, key wrap)
+to the age v1 specification — piggy does not add a second layer of
+its own KEM on top of age. The recovery cipher / shamir share
+logic in `Ebox::create` (`crates/piggy-box/src/ebox.rs`) wraps the
+share-bytes payload identically for both `PivBox` and `AgeBox`
+parts, so the threshold (N=1 of M for Primary; N=M' of M for
+Recovery) remains family-agnostic.
+
+### Encrypt Pipeline
+
+`piggy_box::recipients::tpl_part_from_markl` is the routing point.
+It already validates and routes today; the remaining work is to
+have `age_part_from_markl` produce a real `EboxTplPart` with
+`kind = Age` instead of returning `UnsupportedRecipientFormat`.
+
+`Ebox::create` then dispatches on kind:
+
+- `Piv`: existing `PivBox::seal_offline_with_ephemeral` path
+  (RFC 0002 §6).
+- `Age`: load the recipient pubkey, build an
+  `age::x25519::Recipient`, encrypt the share with
+  `age::Encryptor::with_recipients(vec![recipient])`, store the
+  produced bytes as `stanza_bytes`.
+
+### Decrypt Pipeline
+
+Today, `src/piggy.sh::piggy_decrypt` shells out to the C
+`pivy-box stream decrypt` binary. That binary only knows v1 +
+`PivBox`. Under this RFC, `piggy_decrypt` switches to a new
+`piggy-ids decrypt` Rust subcommand that:
+
+1. Reads the ebox stream and parses the template.
+2. Enumerates parts; for each part tries the kind-specific unwrap:
+   - `Piv`: existing piggy-piv path (SSH-agent ECDH oracle today
+     via `crates/piggy-box::oracle`; direct PC/SC oracle planned in
+     piggy#57).
+   - `Age`: load identities from `$PIGGY_AGE_IDENTITY` (default
+     `~/.config/piggy/age-identity`) via `age::IdentityFile`. This
+     transparently handles plugin identities, so an
+     `AGE-PLUGIN-YUBIKEY-…` identity invokes the
+     `age-plugin-yubikey` binary the same way age does natively.
+3. First successful unwrap wins. If every part fails, surface
+   per-part errors so the user can distinguish "card unplugged"
+   from "wrong age identity" from "plugin binary missing".
+
+### `piggy-ids` File Grammar
+
+No grammar change beyond RFC 0003 §4.2 (broadened to accept
+`age_x25519_pub`). Mixed `piggy-ids` files (pivy + age recipients)
+produce a single ebox whose Primary config carries one part per
+recipient with `n=1`.
+
+### Identity Configuration
+
+- `PIGGY_AGE_IDENTITY` — path to an age identity file (default
+  `~/.config/piggy/age-identity`). Same format as the file
+  consumed by `age --identity` (one identity per line; lines
+  starting with `AGE-SECRET-KEY-1…` or `AGE-PLUGIN-…`).
+- Multiple identities in the file are tried in order against each
+  age part until one succeeds.
+- A missing identity file is not an error when no age parts are
+  present in the ebox; it IS an error when at least one age part
+  exists and no other part decrypts.
+
+### Build/Dependency Changes
+
+- `piggy-box` adds the `age` crate (with the `plugin` feature) as
+  a direct dependency.
+- `flake.nix` adds `age-plugin-yubikey` to `runtimeDeps` so
+  hardware-backed age identities work out of the box. (The base
+  `age` / `rage` binaries are NOT required — piggy uses the
+  library, not the CLI.)
+
+## Security Considerations
+
+1. **Cross-family share isolation.** Each recipient's share is
+   wrapped independently. Compromise of one family's identity
+   (e.g. an exfiltrated age secret) exposes only the corresponding
+   share's plaintext, not the others'. The threshold rule (N=1 for
+   Primary) means that compromise of any one identity in the file
+   is sufficient to decrypt the body — this is unchanged from the
+   all-pivy case, but worth restating since adding age widens the
+   attack surface by adding new identity-holding endpoints (e.g.
+   laptops with age secret keys are now in scope).
+
+2. **No KEM-on-KEM stacking.** Age stanzas are stored verbatim
+   inside `AgeBox`; piggy does not re-wrap, re-encode, or
+   otherwise interpret them. This keeps the security argument
+   for the age path co-extensive with age v1's security argument
+   (Curve25519 ECDH → HKDF → ChaCha20-Poly1305) and avoids
+   inventing piggy-specific crypto on top.
+
+3. **Plugin-identity trust.** When the configured identity
+   references a plugin (e.g. `AGE-PLUGIN-YUBIKEY-…`), piggy hands
+   control to the `age` crate, which invokes the named plugin
+   binary. Operators MUST ensure the plugin binary on PATH is the
+   intended one; piggy SHOULD provide a clear error message when
+   a referenced plugin binary is missing.
+
+4. **Format-confusion across recipient families.** Markl
+   purpose+format validation prevents an `age_x25519_pub` payload
+   from being mis-routed into the PIV path or vice versa (RFC 0002
+   §8.3 plus the broadened RFC 0003 §4.2). The wire-format
+   discriminator (`part-kind` byte) gives a second, redundant
+   gate at the ebox layer; readers MUST reject a part whose
+   kind+payload disagree (e.g. kind=Piv with an age-shaped 32-byte
+   pubkey) instead of attempting a recovery fallback.
+
+## Backwards Compatibility
+
+- Existing v1 ebox files (PIV-only) MUST remain decryptable after
+  this RFC lands. The Rust decrypt dispatcher MUST detect v1 by
+  the version byte and dispatch accordingly.
+- New encryptions to PIV-only recipient sets MAY continue to
+  produce v1 ebox files for maximum compatibility with legacy
+  tooling, OR MAY produce v2. The reference implementation
+  produces v2 by default; the version is metadata, not a security
+  boundary.
+- Encrypting to a set that contains at least one age recipient
+  MUST produce v2.
+
+## Implementation Plan
+
+1. **piggy-markl `PiggyRecipientV1` broadening.** **Done** —
+   accepts `AgeX25519Pub` in addition to `PivyEcdhP256Pub`.
+2. **`piggy-ids` parser broadening.** **Done** — file parser,
+   `Recipient::new`, and `validate_recipient_shape` accept the
+   broadened format set.
+3. **`piggy-box::age_part_from_markl` skeleton.** **Done** —
+   validates the markl input and returns
+   `BoxError::UnsupportedRecipientFormat` pending wire-format
+   work.
+4. **Ebox v2 wire-format extension.** **TODO** — add part-kind
+   discriminator; introduce `AgeBox` part variant; bump
+   `EBOX_VERSION` from 3 to 4 (or add a v2 template variant
+   alongside the existing v1 template). Touches
+   `crates/piggy-box/src/template.rs` and `ebox.rs`.
+5. **`AgeBox` primitive.** **TODO** — implement
+   `crates/piggy-box/src/age_box.rs` with seal/unwrap via the
+   `age` crate. Round-trip tests with known X25519 keypairs.
+6. **`piggy-ids decrypt` subcommand.** **TODO** — Rust-side
+   decrypt dispatcher that handles v1 + v2 ebox files, routing
+   PIV parts through the existing path and age parts through
+   `age::IdentityFile`.
+7. **`piggy.sh` decrypt re-point.** **TODO** — swap
+   `piggy_decrypt()` and `reencrypt_path()` from
+   `pivy-box stream decrypt` to `piggy-ids decrypt`.
+8. **`flake.nix`.** **TODO** — add `age-plugin-yubikey` to
+   `runtimeDeps`.
+9. **bats coverage.** **TODO** — new
+   `zz-tests_bats/t0150-age-recipients.bats` exercising
+   homogeneous-age, homogeneous-pivy (regression), and mixed
+   stores.
+
+## References
+
+### Normative
+
+- amarbel-llc/madder RFC 0002 — Markl ID Format
+- piggy RFC 0002 — PIV ECDH Box wire format
+- piggy RFC 0003 — `piggy-ids` File Format (broadened in §4.2)
+- age v1 specification — <https://age-encryption.org/v1>
+
+### Informative
+
+- piggy#3 — Rust parity roadmap (umbrella tracker)
+- piggy#26 — Sequenced work triage
+- piggy#56/#57 — direct PC/SC paths in piggy-piv (precondition for
+  removing the SSH-agent ECDH oracle from the decrypt path)
+- `crates/piggy-box/src/recipients.rs` — markl → template router
+- `crates/piggy-markl/src/purpose.rs` — `PiggyRecipientV1` accepted
+  format set


### PR DESCRIPTION
Broaden the piggy-recipient-v1 purpose so a piggy-ids file may list
age v1 X25519 recipients alongside (or instead of) PIV ECDH P-256
recipients, and route the new format through piggy-box's recipient
plumbing. This is the markl/parser slice of the age-recipient work
described in the new RFC 0004; the ebox wire-format extension that
lets the encrypt pipeline actually produce age parts is tracked
there and lands separately.

* piggy-markl PiggyRecipientV1 now accepts PivyEcdhP256Pub OR
  AgeX25519Pub; the secret-key form is still rejected as an
  identity, not a recipient.
* piggy-ids parser/Recipient::new accept the broadened format set
  (single source of truth via is_recipient_format); error message
  and module docs updated; new tests cover age-only, mixed, and
  bare-age-format → canonical purpose-tagged renders.
* piggy-box::recipients gains piv_part_from_markl /
  age_part_from_markl; tpl_part_from_markl routes on FormatId.
  The age branch validates the markl input and returns
  BoxError::UnsupportedRecipientFormat (new variant) pointing
  callers at RFC 0004 — markl-level validation, canonicalisation,
  and diffing for age recipients are fully operational, only the
  encrypt-pipeline wire-format step is gated.
* RFC 0003 §Abstract / §Overview / §Line Grammar / §Recipient
  Constraint / §Example / §Security Considerations updated to
  describe the broadened format set and the mixed-recipient
  semantics.
* RFC 0004 (draft) added: pins the AgeBox part variant, the ebox
  v2 wire-format extension, the piggy-ids decrypt Rust dispatcher,
  the PIGGY_AGE_IDENTITY identity-file location, and the
  age-plugin-yubikey integration path. Includes a step-by-step
  implementation checklist with the markl slice marked Done.

Note on Phase 1 scoping: the executing environment has no network
access to crates.io, so the age crate dependency, the AgeBox
seal/unwrap primitive, the piggy-ids decrypt subcommand, the
piggy.sh decrypt re-point, the flake.nix age-plugin-yubikey
runtimeDep addition, and end-to-end bats coverage all defer to a
follow-up commit. RFC 0004 §Implementation Plan tracks the
sequence.

https://claude.ai/code/session_01LZHzAHdVw7LBGAM8heCaC4