### PR TITLE
feat(fibby): pcsc-lite daemon server + virtual/hardware backends + design

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "fibby"
+version = "0.1.0"
+dependencies = [
+ "pcsc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/fib-wait-ready",
+    "crates/fibby",
     "crates/piggy",
     "crates/piggy-box",
     "crates/piggy-ids",

--- a/crates/fibby/Cargo.toml
+++ b/crates/fibby/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "fibby"
+version = "0.1.0"
+edition = "2021"
+description = "Pure-Rust virtual PIV smart card that speaks the pcsc-lite client protocol directly (no pcscd / vsmartcard)."
+
+[[bin]]
+name = "fibby"
+path = "src/main.rs"
+
+[features]
+# The hardware-proxy backend forwards client calls to a real pcscd via
+# libpcsclite (the `pcsc` crate). Gated so the protocol core + virtual
+# backend build and unit-test on hosts without PCSC headers (e.g. CI
+# containers, darwin). Enable on a machine with a real reader to capture
+# /validate against hardware: `cargo run -p fibby --features hardware-proxy`.
+default = []
+hardware-proxy = ["dep:pcsc"]
+
+[dependencies]
+pcsc = { version = "2.9", optional = true }

--- a/crates/fibby/README.md
+++ b/crates/fibby/README.md
@@ -1,0 +1,101 @@
+# fibby — pure-Rust virtual PIV smart card
+
+fibby implements the **pcsc-lite daemon protocol** in Rust, so PC/SC
+clients (`pivy-tool`, `piggy`, `opensc-tool`) connect straight to it via
+`PCSCLITE_CSOCK_NAME` — **no `pcscd`, no `vsmartcard-vpcd`, no Java**.
+This is the self-contained replacement for the `fib` stack
+(`docs/virtual-piv.md`). Design + rationale:
+[`docs/plans/2026-05-29-fibby-virtual-piv-rust-design.md`](../../docs/plans/2026-05-29-fibby-virtual-piv-rust-design.md).
+
+## Module map
+
+Each module is small and independently testable — edit one without
+holding the rest in your head.
+
+| Module | Responsibility |
+|---|---|
+| `proto.rs` | pcsc-lite wire codec (structs ↔ bytes), protocol **4.6**. Source of truth: `LudovicRousseau/PCSC` `winscard_msg.{h,c}`. |
+| `frame.rs` | message framing: 8-byte header + body in, bare struct out, streamed payloads (TRANSMIT). |
+| `error.rs` | `SCARD_*` return codes. |
+| `trace.rs` | `FIBBY_LOG`-gated logging + hex dumps (the debugging firehose). |
+| `backend.rs` | the `Backend` trait — the seam between protocol and card. |
+| `virtual_card.rs` | in-Rust PIV card. **Stub today**: SELECT→9000, else 6D00. Real applet is phase-5. |
+| `hardware_proxy.rs` | forwards to a real pcscd/YubiKey via the `pcsc` crate. Feature `hardware-proxy`. The validation oracle. |
+| `server.rs` | listen loop + per-command dispatch + handle table. |
+
+## Build & test (no hardware, any platform)
+
+```sh
+cargo test -p fibby --no-default-features
+```
+
+This covers the codec unit tests **and** `tests/loopback.rs` — a full
+PC/SC session (handshake → establish → readers-state → connect →
+transmit SELECT → disconnect) driven over a real Unix socket against the
+`VirtualCard`. No pcscd, no card.
+
+## Debugging
+
+```sh
+FIBBY_LOG=info    # connection lifecycle, one line per command
+FIBBY_LOG=debug   # + decoded struct fields
+FIBBY_LOG=wire    # + full hex dump of every rx/tx body + APDU
+```
+
+## Hardware validation runbook (wet-env)
+
+The point of the proxy pattern: run the *same* protocol server in front
+of a real YubiKey and confirm clients behave, then trust the virtual
+path. Needs `libpcsclite-dev` + a running system `pcscd` + a plugged-in
+YubiKey.
+
+```sh
+# 1. Build with the hardware backend.
+cargo build -p fibby --features hardware-proxy
+
+# 2. Run fibby as a proxy to the real card, wire-logging everything.
+mkdir -p /tmp/fibby
+FIBBY_LOG=wire ./target/debug/fibby \
+  --backend hardware --reader Yubico --socket /tmp/fibby/pcscd.comm &
+
+# 3. Point a client at fibby (NOT the system pcscd) and exercise PIV.
+export PCSCLITE_CSOCK_NAME=/tmp/fibby/pcscd.comm
+pivy-tool list
+pivy-tool -P 123456 -K default generate 9d   # real card touched THROUGH fibby
+```
+
+If `pivy-tool` works through fibby, the protocol layer is correct. The
+`FIBBY_LOG=wire` capture is then the conformance fixture the
+`VirtualCard` must reproduce.
+
+### What to extend (and where it screams at you)
+
+`server.rs::handle_client` handles VERSION, ESTABLISH/RELEASE_CONTEXT,
+GET_READERS_STATE, CONNECT, RECONNECT, DISCONNECT, BEGIN/END_TRANSACTION,
+TRANSMIT, STATUS, CANCEL, WAIT_READER_STATE_CHANGE. Any **other** command
+is logged at `info` as `UNIMPLEMENTED command … — closing` and the
+connection drops. That is deliberate: when a real client needs a command
+fibby doesn't speak yet (likely candidates: `GET_ATTRIB`,
+`CMD_GET_READERS_STATE_SIZE`/`ARRAY` on newer libpcsclite), you see
+*exactly* what it sent in the log, with its body hex-dumped, and add a
+handler. No silent wrong-sized replies.
+
+### Spots flagged for wet-env confirmation
+
+Search the source for these — each is a documented assumption that real
+hardware will confirm or correct:
+
+- `proto.rs` `ReaderState` — the 184-byte layout / 3-byte ATR padding.
+- `server.rs` `wait_reader_state` — static-card timeout semantics.
+- `server.rs` `status` — SCardStatus detail comes from the cached
+  reader-state array; the round-trip only carries hCard + rv.
+- `virtual_card.rs` `YUBIKEY5_ATR` — replace with the captured ATR.
+- `hardware_proxy.rs` `map_err` — pcsc→SCARD code mapping.
+
+## Status
+
+Protocol server + both backends + loopback coverage are landed.
+`VirtualCard` is a stub pending the PIV applet (GENERATE / GENERAL
+AUTHENTICATE / GET·PUT DATA / VERIFY / YubiKey attestation+serial),
+which is validated against RFC 0002 Appendix A and SP 800-73-4 vectors —
+see the design doc's phasing.

--- a/crates/fibby/src/apdu.rs
+++ b/crates/fibby/src/apdu.rs
@@ -1,0 +1,21 @@
+//! Minimal ISO 7816-4 / PIV constants fibby's card side needs.
+//!
+//! Intentionally tiny and local for now. The fuller vocabulary lives in
+//! `crates/piggy-piv` (the host-side client); when the real PIV applet
+//! lands, the shared subset (AIDs, INS codes, algorithm IDs, GA template
+//! tags) should move to a common module so client and card cannot drift
+//! — same discipline as `store.rs`/`git_ops.rs`. See the design doc.
+
+/// Full PIV application AID (NIST SP 800-73-4): RID ‖ PIX ‖ version.
+pub const PIV_AID: &[u8] = &[
+    0xA0, 0x00, 0x00, 0x03, 0x08, 0x00, 0x00, 0x10, 0x00, 0x01, 0x00,
+];
+
+/// PIV AID prefix (RID + application portion) a client SELECTs by; the
+/// trailing version bytes are optional in the SELECT data field.
+pub const PIV_AID_PREFIX: &[u8] = &[0xA0, 0x00, 0x00, 0x03, 0x08];
+
+/// ISO 7816-4 instruction bytes fibby's stub recognizes.
+pub mod ins {
+    pub const SELECT: u8 = 0xA4;
+}

--- a/crates/fibby/src/backend.rs
+++ b/crates/fibby/src/backend.rs
@@ -1,0 +1,47 @@
+//! The `Backend` trait: the seam between fibby's pcsc-lite protocol
+//! server and *what's behind the reader*.
+//!
+//! Two implementors:
+//!
+//! - [`crate::virtual_card::VirtualCard`] — the in-Rust PIV applet (the
+//!   goal). Always available.
+//! - [`crate::hardware_proxy::HardwareProxy`] — forwards to a real
+//!   `pcscd` → real YubiKey via the `pcsc` crate. Behind the
+//!   `hardware-proxy` Cargo feature. This is the validation oracle:
+//!   run the *same* protocol server in front of real silicon, confirm
+//!   `pivy-tool`/`piggy` behave, then trust the virtual path.
+//!
+//! Keeping the backend this small (connect / transmit / disconnect +
+//! reader metadata) is deliberate: transactions, reconnect, and
+//! status detail are handled protocol-side in `server.rs` so a backend
+//! author only has to model a card, not the daemon.
+
+/// Outcome of a backend operation: either an active protocol /
+/// response, or an `SCARD_*` code to put on the wire verbatim.
+pub type ScardResult<T> = Result<T, u32>;
+
+pub trait Backend: Send {
+    /// Reader name advertised to clients (the string `SCardListReaders`
+    /// returns). pcsc-lite reader names conventionally end with a
+    /// ` NN NN` slot suffix, e.g. `Yubico YubiKey OTP+FIDO+CCID 00 00`.
+    fn reader_name(&self) -> String;
+
+    /// Whether a card is currently present in the reader.
+    fn card_present(&self) -> bool;
+
+    /// ATR of the present card (empty if absent).
+    fn atr(&self) -> Vec<u8>;
+
+    /// Power up and select the card. Returns the active protocol
+    /// (`proto::protocol::T0`/`T1`) negotiated, or an `SCARD_*` error.
+    fn connect(&mut self, share_mode: u32, preferred_protocols: u32) -> ScardResult<u32>;
+
+    /// Tear down a connection with the given disposition
+    /// (`proto::disposition::*`). LEAVE/RESET/UNPOWER/EJECT.
+    fn disconnect(&mut self, disposition: u32) -> ScardResult<()>;
+
+    /// Transmit a command APDU, returning the full response (data ‖ SW1
+    /// SW2). The protocol layer streams this straight back to the
+    /// client; the backend does no framing of its own.
+    fn transmit(&mut self, command_apdu: &[u8]) -> ScardResult<Vec<u8>>;
+}

--- a/crates/fibby/src/error.rs
+++ b/crates/fibby/src/error.rs
@@ -1,0 +1,20 @@
+//! `SCARD_*` return codes (pcsclite.h / PCSC/pcsclite.h).
+//!
+//! These travel in the `rv` field of every response struct. Only the
+//! subset fibby actually returns is listed; extend as commands grow.
+//! Values are the canonical PC/SC codes so real clients render the
+//! familiar error strings.
+
+pub const SCARD_S_SUCCESS: u32 = 0x0000_0000;
+pub const SCARD_F_INTERNAL_ERROR: u32 = 0x8010_0001;
+pub const SCARD_E_INVALID_HANDLE: u32 = 0x8010_0003;
+pub const SCARD_E_INVALID_VALUE: u32 = 0x8010_0011;
+pub const SCARD_E_NO_SMARTCARD: u32 = 0x8010_000C;
+pub const SCARD_E_UNKNOWN_READER: u32 = 0x8010_0009;
+pub const SCARD_E_NOT_TRANSACTED: u32 = 0x8010_0016;
+pub const SCARD_E_READER_UNAVAILABLE: u32 = 0x8010_0017;
+pub const SCARD_E_SHARING_VIOLATION: u32 = 0x8010_000B;
+pub const SCARD_E_PROTO_MISMATCH: u32 = 0x8010_000F;
+pub const SCARD_E_NO_SERVICE: u32 = 0x8010_001D;
+pub const SCARD_W_REMOVED_CARD: u32 = 0x8010_0069;
+pub const SCARD_W_UNRESPONSIVE_CARD: u32 = 0x8010_0066;

--- a/crates/fibby/src/frame.rs
+++ b/crates/fibby/src/frame.rs
@@ -1,0 +1,144 @@
+//! pcsc-lite message framing over a byte stream (the `pcscd.comm`
+//! Unix socket).
+//!
+//! Asymmetry worth remembering (winscard_msg.c):
+//!
+//! - **client → server**: an 8-byte `rxHeader { size, command }` then a
+//!   `size`-byte body. Some commands (TRANSMIT, GET_ATTRIB) stream extra
+//!   variable-length data *after* the fixed body, with no second header —
+//!   the server knows to read it from the just-decoded struct.
+//! - **server → client**: a *bare* body, no header. The client already
+//!   knows the size it asked for, so the daemon never re-sends a header.
+//!
+//! These helpers keep that asymmetry explicit so the server code reads
+//! the way the protocol actually works.
+
+use std::io::{self, Read, Write};
+
+use crate::proto::{Header, HEADER_LEN};
+
+/// Reject absurd body sizes early. A real request body tops out around
+/// `getset_struct` / extended APDU buffers (~64 KiB); 1 MiB is a generous
+/// ceiling that still stops a malformed/hostile `size` from allocating
+/// the address space.
+pub const MAX_BODY: usize = 1024 * 1024;
+
+/// Read one client→server message: the header plus its fixed body.
+/// Returns `Ok(None)` on a clean EOF at the message boundary (client
+/// disconnected), `Err` on a partial/short read or oversized body.
+pub fn read_message(r: &mut impl Read) -> io::Result<Option<(Header, Vec<u8>)>> {
+    let mut hbuf = [0u8; HEADER_LEN];
+    match read_full(r, &mut hbuf)? {
+        ReadOutcome::Eof => return Ok(None),
+        ReadOutcome::Short => {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "short read on rxHeader",
+            ))
+        }
+        ReadOutcome::Full => {}
+    }
+    let header = Header::from_bytes(&hbuf).expect("HEADER_LEN bytes decode");
+    let size = header.size as usize;
+    if size > MAX_BODY {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("body size {size} exceeds MAX_BODY {MAX_BODY}"),
+        ));
+    }
+    let mut body = vec![0u8; size];
+    r.read_exact(&mut body)?;
+    Ok(Some((header, body)))
+}
+
+/// Read exactly `n` more bytes (a command's trailing variable-length
+/// payload, e.g. the TRANSMIT send buffer).
+pub fn read_payload(r: &mut impl Read, n: usize) -> io::Result<Vec<u8>> {
+    if n > MAX_BODY {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("payload size {n} exceeds MAX_BODY {MAX_BODY}"),
+        ));
+    }
+    let mut buf = vec![0u8; n];
+    r.read_exact(&mut buf)?;
+    Ok(buf)
+}
+
+/// Write a server→client response body (no header) and flush.
+pub fn write_body(w: &mut impl Write, body: &[u8]) -> io::Result<()> {
+    w.write_all(body)?;
+    w.flush()
+}
+
+enum ReadOutcome {
+    Full,
+    Short,
+    Eof,
+}
+
+/// Like `read_exact` but distinguishes a clean EOF-at-boundary (zero
+/// bytes read) from a truncated read, so the caller can treat client
+/// disconnects as normal rather than as errors.
+fn read_full(r: &mut impl Read, buf: &mut [u8]) -> io::Result<ReadOutcome> {
+    let mut filled = 0;
+    while filled < buf.len() {
+        match r.read(&mut buf[filled..]) {
+            Ok(0) => {
+                return Ok(if filled == 0 {
+                    ReadOutcome::Eof
+                } else {
+                    ReadOutcome::Short
+                });
+            }
+            Ok(n) => filled += n,
+            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(ReadOutcome::Full)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::{Command, VersionStruct};
+    use std::io::Cursor;
+
+    #[test]
+    fn reads_header_and_body() {
+        let ver = VersionStruct {
+            major: 4,
+            minor: 6,
+            rv: 0,
+        };
+        let mut wire = Header {
+            size: VersionStruct::WIRE_LEN as u32,
+            command: Command::Version as u32,
+        }
+        .to_bytes()
+        .to_vec();
+        wire.extend_from_slice(&ver.to_bytes());
+        let mut cur = Cursor::new(wire);
+        let (h, body) = read_message(&mut cur).unwrap().unwrap();
+        assert_eq!(h.command, Command::Version as u32);
+        assert_eq!(VersionStruct::from_bytes(&body), Some(ver));
+    }
+
+    #[test]
+    fn clean_eof_is_none_not_error() {
+        let mut empty = Cursor::new(Vec::new());
+        assert!(read_message(&mut empty).unwrap().is_none());
+    }
+
+    #[test]
+    fn oversized_body_is_rejected() {
+        let wire = Header {
+            size: (MAX_BODY + 1) as u32,
+            command: Command::Transmit as u32,
+        }
+        .to_bytes();
+        let mut cur = Cursor::new(wire.to_vec());
+        assert!(read_message(&mut cur).is_err());
+    }
+}

--- a/crates/fibby/src/frame.rs
+++ b/crates/fibby/src/frame.rs
@@ -15,7 +15,7 @@
 
 use std::io::{self, Read, Write};
 
-use crate::proto::{Header, HEADER_LEN};
+use crate::proto::{HEADER_LEN, Header};
 
 /// Reject absurd body sizes early. A real request body tops out around
 /// `getset_struct` / extended APDU buffers (~64 KiB); 1 MiB is a generous
@@ -34,7 +34,7 @@ pub fn read_message(r: &mut impl Read) -> io::Result<Option<(Header, Vec<u8>)>> 
             return Err(io::Error::new(
                 io::ErrorKind::UnexpectedEof,
                 "short read on rxHeader",
-            ))
+            ));
         }
         ReadOutcome::Full => {}
     }

--- a/crates/fibby/src/hardware_proxy.rs
+++ b/crates/fibby/src/hardware_proxy.rs
@@ -62,7 +62,11 @@ impl HardwareProxy {
             format!("no reader matching {reader_substr:?}; is the card plugged in and pcscd up?")
         })?;
         let reader_name = reader.to_string_lossy().into_owned();
-        trace::emit(trace::INFO, "proxy", &format!("selected reader: {reader_name}"));
+        trace::emit(
+            trace::INFO,
+            "proxy",
+            &format!("selected reader: {reader_name}"),
+        );
 
         let mut me = HardwareProxy {
             ctx,
@@ -72,7 +76,10 @@ impl HardwareProxy {
             cached_atr: Vec::new(),
         };
         // Best-effort ATR probe (LEAVE the card as found).
-        if me.connect(crate::proto::share::SHARED, protocol::ANY).is_ok() {
+        if me
+            .connect(crate::proto::share::SHARED, protocol::ANY)
+            .is_ok()
+        {
             me.cached_atr = me.atr();
             let _ = me.disconnect(disposition::LEAVE);
         }
@@ -138,8 +145,9 @@ impl Backend for HardwareProxy {
 
     fn atr(&self) -> Vec<u8> {
         if let Some(card) = &self.card {
-            let mut buf = [0u8; pcsc::MAX_ATR_SIZE];
-            if let Ok(status) = card.status2(&mut buf) {
+            let mut names_buf = [0u8; 256];
+            let mut atr_buf = [0u8; pcsc::MAX_ATR_SIZE];
+            if let Ok(status) = card.status2(&mut names_buf, &mut atr_buf) {
                 return status.atr().to_vec();
             }
         }
@@ -155,13 +163,13 @@ impl Backend for HardwareProxy {
                 Self::map_protocols(preferred_protocols),
             )
             .map_err(Self::map_err)?;
-        let mut buf = [0u8; pcsc::MAX_ATR_SIZE];
-        // `status2().protocol2()` returns a `pcsc::Protocol` directly.
-        let active = match card.status2(&mut buf) {
+        let mut names_buf = [0u8; 256];
+        let mut atr_buf = [0u8; pcsc::MAX_ATR_SIZE];
+        let active = match card.status2(&mut names_buf, &mut atr_buf) {
             Ok(s) => {
                 self.cached_atr = s.atr().to_vec();
                 match s.protocol2() {
-                    pcsc::Protocol::T0 => protocol::T0,
+                    Some(pcsc::Protocol::T0) => protocol::T0,
                     _ => protocol::T1,
                 }
             }
@@ -189,7 +197,9 @@ impl Backend for HardwareProxy {
         // PIV responses fit in the short buffer except chained reads;
         // use the extended buffer to be safe.
         let mut rx = vec![0u8; pcsc::MAX_BUFFER_SIZE_EXTENDED];
-        let resp = card.transmit(command_apdu, &mut rx).map_err(Self::map_err)?;
+        let resp = card
+            .transmit(command_apdu, &mut rx)
+            .map_err(Self::map_err)?;
         Ok(resp.to_vec())
     }
 }

--- a/crates/fibby/src/hardware_proxy.rs
+++ b/crates/fibby/src/hardware_proxy.rs
@@ -1,0 +1,195 @@
+//! `HardwareProxy` — forward fibby's backend calls to a *real* `pcscd`
+//! → real reader/YubiKey via the `pcsc` crate.
+//!
+//! This is the validation oracle. Run fibby with this backend on a
+//! machine that has a YubiKey plugged into the system `pcscd`, point a
+//! client at fibby's socket, and you are exercising fibby's pcsc-lite
+//! *protocol server* in front of genuine silicon. If `pivy-tool list`
+//! and `pivy-tool generate 9d` work through fibby, the protocol layer
+//! is correct — and the captured wire traffic (`FIBBY_LOG=wire`)
+//! becomes the conformance fixtures the `VirtualCard` must replay.
+//!
+//! Gated behind the `hardware-proxy` Cargo feature so the protocol core
+//! and `VirtualCard` build/test on hosts with no PCSC headers (CI
+//! containers, darwin).
+//!
+//! Notes for the wet-env agents:
+//! - The reader is selected by substring (`--reader <substr>`), default
+//!   "Yubico". First match wins; all readers are logged at INFO.
+//! - `pcsc::Error` is mapped to the closest `SCARD_*` code *and* logged
+//!   verbatim, so a mismatch between the real code and fibby's mapping
+//!   is visible rather than silently coerced.
+//! - This holds one `pcsc::Card` at a time (single-client validation).
+
+use std::ffi::CString;
+
+use pcsc::{Context, Disposition, Protocols, Scope, ShareMode};
+
+use crate::backend::{Backend, ScardResult};
+use crate::error::*;
+use crate::proto::{disposition, protocol};
+use crate::trace;
+
+pub struct HardwareProxy {
+    ctx: Context,
+    reader: CString,
+    reader_name: String,
+    card: Option<pcsc::Card>,
+    cached_atr: Vec<u8>,
+}
+
+impl HardwareProxy {
+    /// Establish a system context and pick the first reader whose name
+    /// contains `reader_substr`. Probes the ATR once up front.
+    pub fn new(reader_substr: &str) -> Result<Self, String> {
+        let ctx = Context::establish(Scope::System)
+            .map_err(|e| format!("SCardEstablishContext failed: {e}"))?;
+
+        let mut names_buf = [0u8; 2048];
+        let readers = ctx
+            .list_readers(&mut names_buf)
+            .map_err(|e| format!("SCardListReaders failed: {e}"))?;
+
+        let mut chosen: Option<CString> = None;
+        for r in readers {
+            let name = r.to_string_lossy();
+            trace::emit(trace::INFO, "proxy", &format!("reader: {name}"));
+            if chosen.is_none() && name.contains(reader_substr) {
+                chosen = Some(r.to_owned());
+            }
+        }
+        let reader = chosen.ok_or_else(|| {
+            format!("no reader matching {reader_substr:?}; is the card plugged in and pcscd up?")
+        })?;
+        let reader_name = reader.to_string_lossy().into_owned();
+        trace::emit(trace::INFO, "proxy", &format!("selected reader: {reader_name}"));
+
+        let mut me = HardwareProxy {
+            ctx,
+            reader,
+            reader_name,
+            card: None,
+            cached_atr: Vec::new(),
+        };
+        // Best-effort ATR probe (LEAVE the card as found).
+        if me.connect(crate::proto::share::SHARED, protocol::ANY).is_ok() {
+            me.cached_atr = me.atr();
+            let _ = me.disconnect(disposition::LEAVE);
+        }
+        Ok(me)
+    }
+
+    fn map_share(share_mode: u32) -> ShareMode {
+        match share_mode {
+            x if x == crate::proto::share::EXCLUSIVE => ShareMode::Exclusive,
+            x if x == crate::proto::share::DIRECT => ShareMode::Direct,
+            _ => ShareMode::Shared,
+        }
+    }
+
+    fn map_protocols(preferred: u32) -> Protocols {
+        let t0 = preferred & protocol::T0 != 0;
+        let t1 = preferred & protocol::T1 != 0;
+        match (t0, t1) {
+            (true, true) => Protocols::ANY,
+            (true, false) => Protocols::T0,
+            (false, true) => Protocols::T1,
+            (false, false) => Protocols::ANY,
+        }
+    }
+
+    fn map_disposition(d: u32) -> Disposition {
+        match d {
+            x if x == disposition::RESET => Disposition::ResetCard,
+            x if x == disposition::UNPOWER => Disposition::UnpowerCard,
+            x if x == disposition::EJECT => Disposition::EjectCard,
+            _ => Disposition::LeaveCard,
+        }
+    }
+
+    fn map_err(e: pcsc::Error) -> u32 {
+        trace::emit(trace::DEBUG, "proxy", &format!("pcsc error: {e:?}"));
+        match e {
+            pcsc::Error::NoSmartcard => SCARD_E_NO_SMARTCARD,
+            pcsc::Error::RemovedCard => SCARD_W_REMOVED_CARD,
+            pcsc::Error::UnresponsiveCard => SCARD_W_UNRESPONSIVE_CARD,
+            pcsc::Error::UnknownReader => SCARD_E_UNKNOWN_READER,
+            pcsc::Error::ReaderUnavailable => SCARD_E_READER_UNAVAILABLE,
+            pcsc::Error::SharingViolation => SCARD_E_SHARING_VIOLATION,
+            pcsc::Error::ProtoMismatch => SCARD_E_PROTO_MISMATCH,
+            pcsc::Error::InvalidValue => SCARD_E_INVALID_VALUE,
+            pcsc::Error::InvalidHandle => SCARD_E_INVALID_HANDLE,
+            _ => SCARD_F_INTERNAL_ERROR,
+        }
+    }
+}
+
+impl Backend for HardwareProxy {
+    fn reader_name(&self) -> String {
+        self.reader_name.clone()
+    }
+
+    fn card_present(&self) -> bool {
+        // We probed at startup; treat a known ATR as "present". The
+        // server's reader-state reply uses this. Wet-env: if hot-plug
+        // matters, re-probe via SCardGetStatusChange here.
+        !self.cached_atr.is_empty() || self.card.is_some()
+    }
+
+    fn atr(&self) -> Vec<u8> {
+        if let Some(card) = &self.card {
+            let mut buf = [0u8; pcsc::MAX_ATR_SIZE];
+            if let Ok(status) = card.status2(&mut buf) {
+                return status.atr().to_vec();
+            }
+        }
+        self.cached_atr.clone()
+    }
+
+    fn connect(&mut self, share_mode: u32, preferred_protocols: u32) -> ScardResult<u32> {
+        let card = self
+            .ctx
+            .connect(
+                &self.reader,
+                Self::map_share(share_mode),
+                Self::map_protocols(preferred_protocols),
+            )
+            .map_err(Self::map_err)?;
+        let mut buf = [0u8; pcsc::MAX_ATR_SIZE];
+        // `status2().protocol2()` returns a `pcsc::Protocol` directly.
+        let active = match card.status2(&mut buf) {
+            Ok(s) => {
+                self.cached_atr = s.atr().to_vec();
+                match s.protocol2() {
+                    pcsc::Protocol::T0 => protocol::T0,
+                    _ => protocol::T1,
+                }
+            }
+            Err(_) => protocol::T1,
+        };
+        self.card = Some(card);
+        trace::emit(
+            trace::DEBUG,
+            "proxy",
+            &format!("connected, active protocol = {active}"),
+        );
+        Ok(active)
+    }
+
+    fn disconnect(&mut self, disp: u32) -> ScardResult<()> {
+        if let Some(card) = self.card.take() {
+            card.disconnect(Self::map_disposition(disp))
+                .map_err(|(_, e)| Self::map_err(e))?;
+        }
+        Ok(())
+    }
+
+    fn transmit(&mut self, command_apdu: &[u8]) -> ScardResult<Vec<u8>> {
+        let card = self.card.as_ref().ok_or(SCARD_E_INVALID_HANDLE)?;
+        // PIV responses fit in the short buffer except chained reads;
+        // use the extended buffer to be safe.
+        let mut rx = vec![0u8; pcsc::MAX_BUFFER_SIZE_EXTENDED];
+        let resp = card.transmit(command_apdu, &mut rx).map_err(Self::map_err)?;
+        Ok(resp.to_vec())
+    }
+}

--- a/crates/fibby/src/lib.rs
+++ b/crates/fibby/src/lib.rs
@@ -2,10 +2,30 @@
 //! pcsc-lite daemon protocol directly, so PC/SC clients connect to it
 //! with no real `pcscd` or `vsmartcard-vpcd` in the loop.
 //!
-//! Status: scaffolding. The `proto` module (pcsc-lite wire codec) is the
-//! first landed brick. The server event loop, the `Backend` trait
-//! (virtual PIV card + hardware-proxy), and the PIV applet itself follow.
-//! See docs/plans/2026-05-29-fibby-virtual-piv-rust-design.md for the
-//! overall design and the proxy-validation methodology.
+//! Layering (each module is small and independently testable):
+//!
+//! - [`proto`] — pcsc-lite wire codec (structs ↔ bytes), protocol 4.6.
+//! - [`frame`] — message framing over the socket (header + body / bare
+//!   replies / streamed payloads).
+//! - [`error`] — `SCARD_*` return codes.
+//! - [`trace`] — `FIBBY_LOG`-controlled leveled logging + hex dumps.
+//! - [`backend`] — the `Backend` trait (the card seam).
+//! - [`virtual_card`] — the in-Rust PIV card (stub today; real applet is
+//!   phase-5 work).
+//! - [`hardware_proxy`] — forwards to a real pcscd/YubiKey (feature
+//!   `hardware-proxy`); the validation oracle.
+//! - [`server`] — the listen loop + command dispatch.
+//!
+//! See docs/plans/2026-05-29-fibby-virtual-piv-rust-design.md.
 
+pub mod apdu;
+pub mod backend;
+pub mod error;
+pub mod frame;
 pub mod proto;
+pub mod server;
+pub mod trace;
+pub mod virtual_card;
+
+#[cfg(feature = "hardware-proxy")]
+pub mod hardware_proxy;

--- a/crates/fibby/src/lib.rs
+++ b/crates/fibby/src/lib.rs
@@ -1,0 +1,11 @@
+//! fibby — a pure-Rust virtual PIV smart card that implements the
+//! pcsc-lite daemon protocol directly, so PC/SC clients connect to it
+//! with no real `pcscd` or `vsmartcard-vpcd` in the loop.
+//!
+//! Status: scaffolding. The `proto` module (pcsc-lite wire codec) is the
+//! first landed brick. The server event loop, the `Backend` trait
+//! (virtual PIV card + hardware-proxy), and the PIV applet itself follow.
+//! See docs/plans/2026-05-29-fibby-virtual-piv-rust-design.md for the
+//! overall design and the proxy-validation methodology.
+
+pub mod proto;

--- a/crates/fibby/src/main.rs
+++ b/crates/fibby/src/main.rs
@@ -1,15 +1,135 @@
-//! fibby CLI entry point.
+//! fibby CLI.
 //!
-//! Scaffolding only: the listen loop / backend dispatch is not wired yet.
-//! Today this validates the host-endianness assumption the pcsc-lite
-//! codec relies on and prints the protocol version fibby will advertise.
+//! ```text
+//! fibby [--socket PATH] [--backend virtual|hardware] [--reader SUBSTR]
+//!
+//!   --socket PATH      Unix socket to listen on. Default: $FIBBY_SOCK or
+//!                      /tmp/fibby/pcscd.comm. Point clients at it with
+//!                      PCSCLITE_CSOCK_NAME=PATH.
+//!   --backend KIND     'virtual' (default) = in-Rust PIV card.
+//!                      'hardware' = proxy to the system pcscd/YubiKey
+//!                      (requires the `hardware-proxy` build feature).
+//!   --reader SUBSTR    Hardware backend only: reader-name substring to
+//!                      select. Default: "Yubico".
+//!
+//! Logging: FIBBY_LOG=info|debug|wire (see trace.rs). `wire` hex-dumps
+//! every message — the firehose for protocol debugging.
+//! ```
+//!
+//! Validation recipe (on a machine with a YubiKey):
+//! ```sh
+//! FIBBY_LOG=wire cargo run -p fibby --features hardware-proxy -- \
+//!   --backend hardware --socket /tmp/fibby/pcscd.comm &
+//! PCSCLITE_CSOCK_NAME=/tmp/fibby/pcscd.comm pivy-tool list
+//! ```
+
+use std::sync::{Arc, Mutex};
+
+use fibby::backend::Backend;
+use fibby::server::{self, SharedBackend};
+use fibby::{trace, virtual_card::VirtualCard};
+
+struct Args {
+    socket: String,
+    backend: String,
+    reader: String,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let default_socket = std::env::var("FIBBY_SOCK")
+        .unwrap_or_else(|_| "/tmp/fibby/pcscd.comm".to_string());
+    let mut args = Args {
+        socket: default_socket,
+        backend: "virtual".to_string(),
+        reader: "Yubico".to_string(),
+    };
+    let mut it = std::env::args().skip(1);
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--socket" => args.socket = it.next().ok_or("--socket needs a value")?,
+            "--backend" => args.backend = it.next().ok_or("--backend needs a value")?,
+            "--reader" => args.reader = it.next().ok_or("--reader needs a value")?,
+            "-h" | "--help" => {
+                print_help();
+                std::process::exit(0);
+            }
+            other => return Err(format!("unknown argument: {other}")),
+        }
+    }
+    Ok(args)
+}
+
+fn print_help() {
+    eprintln!(
+        "fibby — pure-Rust virtual PIV card over the pcsc-lite protocol\n\
+         \n\
+         USAGE: fibby [--socket PATH] [--backend virtual|hardware] [--reader SUBSTR]\n\
+         \n\
+         Point clients at the socket via PCSCLITE_CSOCK_NAME.\n\
+         Set FIBBY_LOG=info|debug|wire for logging."
+    );
+}
 
 fn main() {
-    fibby::proto::assert_le_host();
-    eprintln!(
-        "fibby: pcsc-lite protocol {}.{} (server loop not yet wired — see \
-         docs/plans/2026-05-29-fibby-virtual-piv-rust-design.md)",
-        fibby::proto::PROTOCOL_VERSION_MAJOR,
-        fibby::proto::PROTOCOL_VERSION_MINOR,
+    proto_sanity();
+    trace::init_from_env();
+
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("fibby: {e}");
+            print_help();
+            std::process::exit(2);
+        }
+    };
+
+    if let Some(dir) = std::path::Path::new(&args.socket).parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+
+    let backend = match make_backend(&args) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("fibby: backend init failed: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    trace::emit(
+        trace::INFO,
+        "main",
+        &format!("backend={} socket={}", args.backend, args.socket),
     );
+    if let Err(e) = server::serve(&args.socket, backend) {
+        eprintln!("fibby: serve failed: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn make_backend(args: &Args) -> Result<SharedBackend, String> {
+    match args.backend.as_str() {
+        "virtual" => Ok(into_shared(VirtualCard::new())),
+        "hardware" => make_hardware_backend(&args.reader),
+        other => Err(format!("unknown backend {other:?} (want 'virtual' or 'hardware')")),
+    }
+}
+
+#[cfg(feature = "hardware-proxy")]
+fn make_hardware_backend(reader: &str) -> Result<SharedBackend, String> {
+    Ok(into_shared(fibby::hardware_proxy::HardwareProxy::new(reader)?))
+}
+
+#[cfg(not(feature = "hardware-proxy"))]
+fn make_hardware_backend(_reader: &str) -> Result<SharedBackend, String> {
+    Err("the 'hardware' backend needs the `hardware-proxy` build feature: \
+         cargo run -p fibby --features hardware-proxy"
+        .to_string())
+}
+
+fn into_shared<B: Backend + 'static>(b: B) -> SharedBackend {
+    Arc::new(Mutex::new(b))
+}
+
+fn proto_sanity() {
+    fibby::proto::assert_le_host();
 }

--- a/crates/fibby/src/main.rs
+++ b/crates/fibby/src/main.rs
@@ -36,8 +36,8 @@ struct Args {
 }
 
 fn parse_args() -> Result<Args, String> {
-    let default_socket = std::env::var("FIBBY_SOCK")
-        .unwrap_or_else(|_| "/tmp/fibby/pcscd.comm".to_string());
+    let default_socket =
+        std::env::var("FIBBY_SOCK").unwrap_or_else(|_| "/tmp/fibby/pcscd.comm".to_string());
     let mut args = Args {
         socket: default_socket,
         backend: "virtual".to_string(),
@@ -110,20 +110,26 @@ fn make_backend(args: &Args) -> Result<SharedBackend, String> {
     match args.backend.as_str() {
         "virtual" => Ok(into_shared(VirtualCard::new())),
         "hardware" => make_hardware_backend(&args.reader),
-        other => Err(format!("unknown backend {other:?} (want 'virtual' or 'hardware')")),
+        other => Err(format!(
+            "unknown backend {other:?} (want 'virtual' or 'hardware')"
+        )),
     }
 }
 
 #[cfg(feature = "hardware-proxy")]
 fn make_hardware_backend(reader: &str) -> Result<SharedBackend, String> {
-    Ok(into_shared(fibby::hardware_proxy::HardwareProxy::new(reader)?))
+    Ok(into_shared(fibby::hardware_proxy::HardwareProxy::new(
+        reader,
+    )?))
 }
 
 #[cfg(not(feature = "hardware-proxy"))]
 fn make_hardware_backend(_reader: &str) -> Result<SharedBackend, String> {
-    Err("the 'hardware' backend needs the `hardware-proxy` build feature: \
+    Err(
+        "the 'hardware' backend needs the `hardware-proxy` build feature: \
          cargo run -p fibby --features hardware-proxy"
-        .to_string())
+            .to_string(),
+    )
 }
 
 fn into_shared<B: Backend + 'static>(b: B) -> SharedBackend {

--- a/crates/fibby/src/main.rs
+++ b/crates/fibby/src/main.rs
@@ -1,0 +1,15 @@
+//! fibby CLI entry point.
+//!
+//! Scaffolding only: the listen loop / backend dispatch is not wired yet.
+//! Today this validates the host-endianness assumption the pcsc-lite
+//! codec relies on and prints the protocol version fibby will advertise.
+
+fn main() {
+    fibby::proto::assert_le_host();
+    eprintln!(
+        "fibby: pcsc-lite protocol {}.{} (server loop not yet wired — see \
+         docs/plans/2026-05-29-fibby-virtual-piv-rust-design.md)",
+        fibby::proto::PROTOCOL_VERSION_MAJOR,
+        fibby::proto::PROTOCOL_VERSION_MINOR,
+    );
+}

--- a/crates/fibby/src/proto.rs
+++ b/crates/fibby/src/proto.rs
@@ -1,0 +1,338 @@
+//! pcsc-lite client/daemon wire protocol (the `pcscd.comm` socket).
+//!
+//! This is the protocol `libpcsclite.so` speaks to `pcscd`. `fibby`
+//! implements the *daemon* side of it so that PC/SC clients (pivy-tool,
+//! piggy, opensc-tool) connect straight to fibby with no real pcscd or
+//! vsmartcard-vpcd in the loop — the clients only need
+//! `PCSCLITE_CSOCK_NAME` pointed at fibby's listening socket.
+//!
+//! Source of truth: LudovicRousseau/PCSC `src/winscard_msg.h` (protocol
+//! 4.6) and `src/winscard_msg.c` (framing). Reproduced field-for-field
+//! below; drift against a real `libpcsclite` is what the hardware-proxy
+//! backend exists to catch.
+//!
+//! ## Framing
+//!
+//! Every exchange is a fixed 8-byte header followed by a command-specific
+//! body of `size` bytes:
+//!
+//! ```text
+//! struct rxHeader { uint32_t size; uint32_t command; }   // 8 bytes
+//! <body: `size` bytes>
+//! ```
+//!
+//! ## Byte order
+//!
+//! pcsc-lite is a *local* IPC: structs are written with the host's native
+//! byte order and natural alignment, no packing attribute. Every field in
+//! the structs we handle is either a 4-byte int or a byte array whose
+//! length is a multiple of 4 placed at a 4-aligned offset, so the packed
+//! little-endian encoding here is bit-identical to the C layout on the
+//! little-endian hosts piggy targets (x86-64, aarch64). A big-endian host
+//! would need byteswapping; we assert LE at the codec boundary rather than
+//! silently mis-encode. See `assert_le_host`.
+
+/// Protocol version fibby advertises in the `CMD_VERSION` handshake.
+/// Must match the client's `libpcsclite` major; a mismatch is the sole
+/// cause of `SCARD_E_SERVICE_STOPPED` (see Rousseau's pcsc-lite FAQ).
+pub const PROTOCOL_VERSION_MAJOR: i32 = 4;
+pub const PROTOCOL_VERSION_MINOR: i32 = 6;
+
+/// `MAX_READERNAME` from pcsclite.h.
+pub const MAX_READERNAME: usize = 128;
+/// `MAX_ATR_SIZE` from pcsclite.h.
+pub const MAX_ATR_SIZE: usize = 33;
+/// `MAX_BUFFER_SIZE` from pcsclite.h (short APDU buffer).
+pub const MAX_BUFFER_SIZE: usize = 264;
+
+/// Size of `struct rxHeader` on the wire.
+pub const HEADER_LEN: usize = 8;
+
+/// `SCARD_S_SUCCESS`. Full status-word vocabulary lives in `error.rs`
+/// once the dispatcher needs it; the codec only needs success here.
+pub const SCARD_S_SUCCESS: u32 = 0x0000_0000;
+
+/// `enum pcsc_msg_commands` (winscard_msg.h). Numeric values are part of
+/// the wire contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum Command {
+    EstablishContext = 0x01,
+    ReleaseContext = 0x02,
+    ListReaders = 0x03,
+    Connect = 0x04,
+    Reconnect = 0x05,
+    Disconnect = 0x06,
+    BeginTransaction = 0x07,
+    EndTransaction = 0x08,
+    Transmit = 0x09,
+    Control = 0x0A,
+    Status = 0x0B,
+    GetStatusChange = 0x0C,
+    Cancel = 0x0D,
+    CancelTransaction = 0x0E,
+    GetAttrib = 0x0F,
+    SetAttrib = 0x10,
+    Version = 0x11,
+    GetReadersState = 0x12,
+    WaitReaderStateChange = 0x13,
+    StopWaitingReaderStateChange = 0x14,
+    GetReaderEvents = 0x15,
+    GetReadersStateSize = 0x16,
+    GetReadersStateArray = 0x17,
+}
+
+impl Command {
+    pub fn from_u32(v: u32) -> Option<Self> {
+        use Command::*;
+        Some(match v {
+            0x01 => EstablishContext,
+            0x02 => ReleaseContext,
+            0x03 => ListReaders,
+            0x04 => Connect,
+            0x05 => Reconnect,
+            0x06 => Disconnect,
+            0x07 => BeginTransaction,
+            0x08 => EndTransaction,
+            0x09 => Transmit,
+            0x0A => Control,
+            0x0B => Status,
+            0x0C => GetStatusChange,
+            0x0D => Cancel,
+            0x0E => CancelTransaction,
+            0x0F => GetAttrib,
+            0x10 => SetAttrib,
+            0x11 => Version,
+            0x12 => GetReadersState,
+            0x13 => WaitReaderStateChange,
+            0x14 => StopWaitingReaderStateChange,
+            0x15 => GetReaderEvents,
+            0x16 => GetReadersStateSize,
+            0x17 => GetReadersStateArray,
+            _ => return None,
+        })
+    }
+}
+
+/// `struct rxHeader { uint32_t size; uint32_t command; }`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Header {
+    pub size: u32,
+    pub command: u32,
+}
+
+impl Header {
+    pub fn to_bytes(&self) -> [u8; HEADER_LEN] {
+        let mut b = [0u8; HEADER_LEN];
+        b[0..4].copy_from_slice(&self.size.to_le_bytes());
+        b[4..8].copy_from_slice(&self.command.to_le_bytes());
+        b
+    }
+
+    pub fn from_bytes(b: &[u8]) -> Option<Self> {
+        if b.len() < HEADER_LEN {
+            return None;
+        }
+        Some(Header {
+            size: u32::from_le_bytes(b[0..4].try_into().ok()?),
+            command: u32::from_le_bytes(b[4..8].try_into().ok()?),
+        })
+    }
+}
+
+/// Marker that the codec's packed-LE layout matches the C struct layout
+/// on this host. Panics on a big-endian target so a mis-encode is loud,
+/// not silent. Cheap; call once at startup.
+pub fn assert_le_host() {
+    assert!(
+        cfg!(target_endian = "little"),
+        "fibby's pcsc-lite codec assumes a little-endian host; big-endian \
+         needs per-field byteswapping (winscard_msg uses native order)"
+    );
+}
+
+/// `struct version_struct { int32_t major; int32_t minor; uint32_t rv; }`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VersionStruct {
+    pub major: i32,
+    pub minor: i32,
+    pub rv: u32,
+}
+
+impl VersionStruct {
+    pub const WIRE_LEN: usize = 12;
+
+    pub fn to_bytes(&self) -> [u8; Self::WIRE_LEN] {
+        let mut b = [0u8; Self::WIRE_LEN];
+        b[0..4].copy_from_slice(&self.major.to_le_bytes());
+        b[4..8].copy_from_slice(&self.minor.to_le_bytes());
+        b[8..12].copy_from_slice(&self.rv.to_le_bytes());
+        b
+    }
+
+    pub fn from_bytes(b: &[u8]) -> Option<Self> {
+        if b.len() < Self::WIRE_LEN {
+            return None;
+        }
+        Some(VersionStruct {
+            major: i32::from_le_bytes(b[0..4].try_into().ok()?),
+            minor: i32::from_le_bytes(b[4..8].try_into().ok()?),
+            rv: u32::from_le_bytes(b[8..12].try_into().ok()?),
+        })
+    }
+}
+
+/// `struct establish_struct { uint32_t dwScope; uint32_t hContext; uint32_t rv; }`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EstablishStruct {
+    pub dw_scope: u32,
+    pub h_context: u32,
+    pub rv: u32,
+}
+
+impl EstablishStruct {
+    pub const WIRE_LEN: usize = 12;
+
+    pub fn to_bytes(&self) -> [u8; Self::WIRE_LEN] {
+        let mut b = [0u8; Self::WIRE_LEN];
+        b[0..4].copy_from_slice(&self.dw_scope.to_le_bytes());
+        b[4..8].copy_from_slice(&self.h_context.to_le_bytes());
+        b[8..12].copy_from_slice(&self.rv.to_le_bytes());
+        b
+    }
+
+    pub fn from_bytes(b: &[u8]) -> Option<Self> {
+        if b.len() < Self::WIRE_LEN {
+            return None;
+        }
+        Some(EstablishStruct {
+            dw_scope: u32::from_le_bytes(b[0..4].try_into().ok()?),
+            h_context: u32::from_le_bytes(b[4..8].try_into().ok()?),
+            rv: u32::from_le_bytes(b[8..12].try_into().ok()?),
+        })
+    }
+}
+
+/// `struct transmit_struct` header (the APDU payloads are streamed
+/// separately after this fixed block, exactly as winscard_msg does).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransmitStruct {
+    pub h_card: i32,
+    pub io_send_pci_protocol: u32,
+    pub io_send_pci_length: u32,
+    pub cb_send_length: u32,
+    pub io_recv_pci_protocol: u32,
+    pub io_recv_pci_length: u32,
+    pub pcb_recv_length: u32,
+    pub rv: u32,
+}
+
+impl TransmitStruct {
+    pub const WIRE_LEN: usize = 32;
+
+    pub fn to_bytes(&self) -> [u8; Self::WIRE_LEN] {
+        let mut b = [0u8; Self::WIRE_LEN];
+        b[0..4].copy_from_slice(&self.h_card.to_le_bytes());
+        b[4..8].copy_from_slice(&self.io_send_pci_protocol.to_le_bytes());
+        b[8..12].copy_from_slice(&self.io_send_pci_length.to_le_bytes());
+        b[12..16].copy_from_slice(&self.cb_send_length.to_le_bytes());
+        b[16..20].copy_from_slice(&self.io_recv_pci_protocol.to_le_bytes());
+        b[20..24].copy_from_slice(&self.io_recv_pci_length.to_le_bytes());
+        b[24..28].copy_from_slice(&self.pcb_recv_length.to_le_bytes());
+        b[28..32].copy_from_slice(&self.rv.to_le_bytes());
+        b
+    }
+
+    pub fn from_bytes(b: &[u8]) -> Option<Self> {
+        if b.len() < Self::WIRE_LEN {
+            return None;
+        }
+        let r = |o: usize| u32::from_le_bytes(b[o..o + 4].try_into().unwrap());
+        Some(TransmitStruct {
+            h_card: i32::from_le_bytes(b[0..4].try_into().ok()?),
+            io_send_pci_protocol: r(4),
+            io_send_pci_length: r(8),
+            cb_send_length: r(12),
+            io_recv_pci_protocol: r(16),
+            io_recv_pci_length: r(20),
+            pcb_recv_length: r(24),
+            rv: r(28),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_roundtrips() {
+        let h = Header {
+            size: VersionStruct::WIRE_LEN as u32,
+            command: Command::Version as u32,
+        };
+        let bytes = h.to_bytes();
+        // Little-endian, 8 bytes: size=0x0000000C, command=0x00000011.
+        assert_eq!(bytes, [0x0C, 0, 0, 0, 0x11, 0, 0, 0]);
+        assert_eq!(Header::from_bytes(&bytes), Some(h));
+    }
+
+    #[test]
+    fn command_numeric_values_match_winscard_msg() {
+        // These are the wire contract; a typo here desyncs every client.
+        assert_eq!(Command::EstablishContext as u32, 0x01);
+        assert_eq!(Command::Transmit as u32, 0x09);
+        assert_eq!(Command::Version as u32, 0x11);
+        assert_eq!(Command::GetReadersStateArray as u32, 0x17);
+        assert_eq!(Command::from_u32(0x0C), Some(Command::GetStatusChange));
+        assert_eq!(Command::from_u32(0xFFFF), None);
+    }
+
+    #[test]
+    fn version_struct_roundtrips() {
+        let v = VersionStruct {
+            major: PROTOCOL_VERSION_MAJOR,
+            minor: PROTOCOL_VERSION_MINOR,
+            rv: SCARD_S_SUCCESS,
+        };
+        let bytes = v.to_bytes();
+        assert_eq!(bytes.len(), 12);
+        // major=4, minor=6, rv=0 — all little-endian.
+        assert_eq!(bytes, [4, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(VersionStruct::from_bytes(&bytes), Some(v));
+    }
+
+    #[test]
+    fn establish_struct_roundtrips() {
+        let e = EstablishStruct {
+            dw_scope: 2, // SCARD_SCOPE_SYSTEM
+            h_context: 0xDEAD_BEEF,
+            rv: SCARD_S_SUCCESS,
+        };
+        assert_eq!(EstablishStruct::from_bytes(&e.to_bytes()), Some(e));
+    }
+
+    #[test]
+    fn transmit_struct_roundtrips_and_is_32_bytes() {
+        let t = TransmitStruct {
+            h_card: 0x1122_3344,
+            io_send_pci_protocol: 2, // T=1
+            io_send_pci_length: 8,
+            cb_send_length: 5,
+            io_recv_pci_protocol: 2,
+            io_recv_pci_length: 8,
+            pcb_recv_length: 258,
+            rv: SCARD_S_SUCCESS,
+        };
+        let bytes = t.to_bytes();
+        assert_eq!(bytes.len(), 32);
+        assert_eq!(TransmitStruct::from_bytes(&bytes), Some(t));
+    }
+
+    #[test]
+    fn from_bytes_rejects_short_input() {
+        assert_eq!(Header::from_bytes(&[0u8; 7]), None);
+        assert_eq!(VersionStruct::from_bytes(&[0u8; 11]), None);
+        assert_eq!(TransmitStruct::from_bytes(&[0u8; 31]), None);
+    }
+}

--- a/crates/fibby/src/proto.rs
+++ b/crates/fibby/src/proto.rs
@@ -140,11 +140,13 @@ impl Header {
 /// on this host. Panics on a big-endian target so a mis-encode is loud,
 /// not silent. Cheap; call once at startup.
 pub fn assert_le_host() {
-    assert!(
-        cfg!(target_endian = "little"),
-        "fibby's pcsc-lite codec assumes a little-endian host; big-endian \
-         needs per-field byteswapping (winscard_msg uses native order)"
-    );
+    const {
+        assert!(
+            cfg!(target_endian = "little"),
+            "fibby's pcsc-lite codec assumes a little-endian host; big-endian \
+             needs per-field byteswapping (winscard_msg uses native order)"
+        );
+    }
 }
 
 /// `struct version_struct { int32_t major; int32_t minor; uint32_t rv; }`.
@@ -425,8 +427,11 @@ impl ReaderState {
         if b.len() < Self::WIRE_LEN {
             return None;
         }
-        let atr_len = u32::from_le_bytes(b[Self::ATR_LEN_OFF..Self::ATR_LEN_OFF + 4].try_into().ok()?)
-            as usize;
+        let atr_len = u32::from_le_bytes(
+            b[Self::ATR_LEN_OFF..Self::ATR_LEN_OFF + 4]
+                .try_into()
+                .ok()?,
+        ) as usize;
         let atr_len = atr_len.min(MAX_ATR_SIZE);
         Some(ReaderState {
             reader_name: read_cstr(&b[0..MAX_READERNAME]),
@@ -434,7 +439,9 @@ impl ReaderState {
             reader_state: u32::from_le_bytes(b[132..136].try_into().ok()?),
             reader_sharing: i32::from_le_bytes(b[136..140].try_into().ok()?),
             card_atr: b[Self::ATR_OFF..Self::ATR_OFF + atr_len].to_vec(),
-            card_protocol: u32::from_le_bytes(b[Self::PROTO_OFF..Self::PROTO_OFF + 4].try_into().ok()?),
+            card_protocol: u32::from_le_bytes(
+                b[Self::PROTO_OFF..Self::PROTO_OFF + 4].try_into().ok()?,
+            ),
         })
     }
 }
@@ -642,15 +649,28 @@ mod tests {
         assert_eq!(arr.len(), MAX_READERS_CONTEXTS * ReaderState::WIRE_LEN);
         assert_eq!(arr.len(), 16 * 184);
         // Slot 0 populated, slot 1 zeroed.
-        assert_eq!(ReaderState::from_bytes(&arr[0..184]).unwrap().reader_name, "r");
-        assert_eq!(ReaderState::from_bytes(&arr[184..368]), Some(ReaderState::empty()));
+        assert_eq!(
+            ReaderState::from_bytes(&arr[0..184]).unwrap().reader_name,
+            "r"
+        );
+        assert_eq!(
+            ReaderState::from_bytes(&arr[184..368]),
+            Some(ReaderState::empty())
+        );
     }
 
     #[test]
     fn handle_codecs_roundtrip() {
-        let a = HandleArgRv { handle: -1, arg: disposition::RESET, rv: 0 };
+        let a = HandleArgRv {
+            handle: -1,
+            arg: disposition::RESET,
+            rv: 0,
+        };
         assert_eq!(HandleArgRv::from_bytes(&a.to_bytes()), Some(a));
-        let h = HandleRv { handle: 7, rv: SCARD_S_SUCCESS };
+        let h = HandleRv {
+            handle: 7,
+            rv: SCARD_S_SUCCESS,
+        };
         assert_eq!(HandleRv::from_bytes(&h.to_bytes()), Some(h));
     }
 

--- a/crates/fibby/src/proto.rs
+++ b/crates/fibby/src/proto.rs
@@ -48,10 +48,6 @@ pub const MAX_BUFFER_SIZE: usize = 264;
 /// Size of `struct rxHeader` on the wire.
 pub const HEADER_LEN: usize = 8;
 
-/// `SCARD_S_SUCCESS`. Full status-word vocabulary lives in `error.rs`
-/// once the dispatcher needs it; the codec only needs success here.
-pub const SCARD_S_SUCCESS: u32 = 0x0000_0000;
-
 /// `enum pcsc_msg_commands` (winscard_msg.h). Numeric values are part of
 /// the wire contract.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -261,9 +257,270 @@ impl TransmitStruct {
     }
 }
 
+/// `struct connect_struct`. `szReader` is a fixed 128-byte
+/// NUL-terminated field on the wire.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectStruct {
+    pub h_context: u32,
+    pub sz_reader: String,
+    pub dw_share_mode: u32,
+    pub dw_preferred_protocols: u32,
+    pub h_card: i32,
+    pub dw_active_protocol: u32,
+    pub rv: u32,
+}
+
+impl ConnectStruct {
+    pub const WIRE_LEN: usize = 4 + MAX_READERNAME + 4 + 4 + 4 + 4 + 4; // 152
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut b = vec![0u8; Self::WIRE_LEN];
+        b[0..4].copy_from_slice(&self.h_context.to_le_bytes());
+        write_cstr(&mut b[4..4 + MAX_READERNAME], &self.sz_reader);
+        let o = 4 + MAX_READERNAME;
+        b[o..o + 4].copy_from_slice(&self.dw_share_mode.to_le_bytes());
+        b[o + 4..o + 8].copy_from_slice(&self.dw_preferred_protocols.to_le_bytes());
+        b[o + 8..o + 12].copy_from_slice(&self.h_card.to_le_bytes());
+        b[o + 12..o + 16].copy_from_slice(&self.dw_active_protocol.to_le_bytes());
+        b[o + 16..o + 20].copy_from_slice(&self.rv.to_le_bytes());
+        b
+    }
+
+    pub fn from_bytes(b: &[u8]) -> Option<Self> {
+        if b.len() < Self::WIRE_LEN {
+            return None;
+        }
+        let o = 4 + MAX_READERNAME;
+        Some(ConnectStruct {
+            h_context: u32::from_le_bytes(b[0..4].try_into().ok()?),
+            sz_reader: read_cstr(&b[4..4 + MAX_READERNAME]),
+            dw_share_mode: u32::from_le_bytes(b[o..o + 4].try_into().ok()?),
+            dw_preferred_protocols: u32::from_le_bytes(b[o + 4..o + 8].try_into().ok()?),
+            h_card: i32::from_le_bytes(b[o + 8..o + 12].try_into().ok()?),
+            dw_active_protocol: u32::from_le_bytes(b[o + 12..o + 16].try_into().ok()?),
+            rv: u32::from_le_bytes(b[o + 16..o + 20].try_into().ok()?),
+        })
+    }
+}
+
+/// Tiny two-field structs (`disconnect_struct`, `end_struct` share a
+/// shape; `begin_struct`, `status_struct`, `release_struct`,
+/// `cancel_struct` are subsets). One codec covers the
+/// `{ i32 handle; u32 arg; u32 rv }` and `{ i32 handle; u32 rv }`
+/// families; callers pick the field count. Keeping these as explicit
+/// little structs (rather than one mega-enum) keeps the dispatcher
+/// readable and easy to extend per command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HandleArgRv {
+    pub handle: i32,
+    pub arg: u32,
+    pub rv: u32,
+}
+
+impl HandleArgRv {
+    pub const WIRE_LEN: usize = 12;
+
+    pub fn to_bytes(&self) -> [u8; Self::WIRE_LEN] {
+        let mut b = [0u8; Self::WIRE_LEN];
+        b[0..4].copy_from_slice(&self.handle.to_le_bytes());
+        b[4..8].copy_from_slice(&self.arg.to_le_bytes());
+        b[8..12].copy_from_slice(&self.rv.to_le_bytes());
+        b
+    }
+
+    pub fn from_bytes(b: &[u8]) -> Option<Self> {
+        if b.len() < Self::WIRE_LEN {
+            return None;
+        }
+        Some(HandleArgRv {
+            handle: i32::from_le_bytes(b[0..4].try_into().ok()?),
+            arg: u32::from_le_bytes(b[4..8].try_into().ok()?),
+            rv: u32::from_le_bytes(b[8..12].try_into().ok()?),
+        })
+    }
+}
+
+/// `{ i32 handle; u32 rv }` — `begin_struct`, `status_struct`,
+/// `release_struct` (with hContext), `cancel_struct`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HandleRv {
+    pub handle: i32,
+    pub rv: u32,
+}
+
+impl HandleRv {
+    pub const WIRE_LEN: usize = 8;
+
+    pub fn to_bytes(&self) -> [u8; Self::WIRE_LEN] {
+        let mut b = [0u8; Self::WIRE_LEN];
+        b[0..4].copy_from_slice(&self.handle.to_le_bytes());
+        b[4..8].copy_from_slice(&self.rv.to_le_bytes());
+        b
+    }
+
+    pub fn from_bytes(b: &[u8]) -> Option<Self> {
+        if b.len() < Self::WIRE_LEN {
+            return None;
+        }
+        Some(HandleRv {
+            handle: i32::from_le_bytes(b[0..4].try_into().ok()?),
+            rv: u32::from_le_bytes(b[4..8].try_into().ok()?),
+        })
+    }
+}
+
+/// `PCSCLITE_MAX_READERS_CONTEXTS` — the fixed slot count in the
+/// reader-state array returned by `CMD_GET_READERS_STATE`.
+pub const MAX_READERS_CONTEXTS: usize = 16;
+
+/// `READER_STATE` (eventhandler.h). 184 bytes including 3 pad bytes
+/// after the 33-byte ATR (so `cardAtrLength` lands on a 4-aligned
+/// offset). The padding is load-bearing: get it wrong and every field
+/// after the ATR shifts. The hardware-proxy backend is the cheapest
+/// way to confirm this against a real `libpcsclite`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReaderState {
+    pub reader_name: String,
+    pub event_counter: u32,
+    pub reader_state: u32,
+    pub reader_sharing: i32,
+    pub card_atr: Vec<u8>,
+    pub card_protocol: u32,
+}
+
+impl ReaderState {
+    pub const WIRE_LEN: usize = 184;
+    const ATR_OFF: usize = 140;
+    const ATR_LEN_OFF: usize = 176; // 140 + 33 = 173, padded up to 176
+    const PROTO_OFF: usize = 180;
+
+    /// An empty/unused slot — all zero, matching pcscd's freshly-zeroed
+    /// reader-state table.
+    pub fn empty() -> Self {
+        ReaderState {
+            reader_name: String::new(),
+            event_counter: 0,
+            reader_state: 0,
+            reader_sharing: 0,
+            card_atr: Vec::new(),
+            card_protocol: 0,
+        }
+    }
+
+    pub fn to_bytes(&self) -> [u8; Self::WIRE_LEN] {
+        let mut b = [0u8; Self::WIRE_LEN];
+        write_cstr(&mut b[0..MAX_READERNAME], &self.reader_name);
+        b[128..132].copy_from_slice(&self.event_counter.to_le_bytes());
+        b[132..136].copy_from_slice(&self.reader_state.to_le_bytes());
+        b[136..140].copy_from_slice(&self.reader_sharing.to_le_bytes());
+        let atr = &self.card_atr[..self.card_atr.len().min(MAX_ATR_SIZE)];
+        b[Self::ATR_OFF..Self::ATR_OFF + atr.len()].copy_from_slice(atr);
+        b[Self::ATR_LEN_OFF..Self::ATR_LEN_OFF + 4]
+            .copy_from_slice(&(atr.len() as u32).to_le_bytes());
+        b[Self::PROTO_OFF..Self::PROTO_OFF + 4].copy_from_slice(&self.card_protocol.to_le_bytes());
+        b
+    }
+
+    pub fn from_bytes(b: &[u8]) -> Option<Self> {
+        if b.len() < Self::WIRE_LEN {
+            return None;
+        }
+        let atr_len = u32::from_le_bytes(b[Self::ATR_LEN_OFF..Self::ATR_LEN_OFF + 4].try_into().ok()?)
+            as usize;
+        let atr_len = atr_len.min(MAX_ATR_SIZE);
+        Some(ReaderState {
+            reader_name: read_cstr(&b[0..MAX_READERNAME]),
+            event_counter: u32::from_le_bytes(b[128..132].try_into().ok()?),
+            reader_state: u32::from_le_bytes(b[132..136].try_into().ok()?),
+            reader_sharing: i32::from_le_bytes(b[136..140].try_into().ok()?),
+            card_atr: b[Self::ATR_OFF..Self::ATR_OFF + atr_len].to_vec(),
+            card_protocol: u32::from_le_bytes(b[Self::PROTO_OFF..Self::PROTO_OFF + 4].try_into().ok()?),
+        })
+    }
+}
+
+/// Serialize a full `READER_STATE[MAX_READERS_CONTEXTS]` array (the
+/// `CMD_GET_READERS_STATE` reply). Slots past `states` are zeroed.
+pub fn readers_state_array(states: &[ReaderState]) -> Vec<u8> {
+    let mut out = vec![0u8; MAX_READERS_CONTEXTS * ReaderState::WIRE_LEN];
+    for (i, st) in states.iter().take(MAX_READERS_CONTEXTS).enumerate() {
+        let off = i * ReaderState::WIRE_LEN;
+        out[off..off + ReaderState::WIRE_LEN].copy_from_slice(&st.to_bytes());
+    }
+    out
+}
+
+/// Write a NUL-terminated string into a fixed-width field, truncating
+/// if needed and always leaving at least the final byte NUL. Zeroes the
+/// whole field first so the result never depends on prior buffer
+/// contents (no implicit "caller must pre-zero" contract).
+fn write_cstr(dst: &mut [u8], s: &str) {
+    dst.fill(0);
+    let max = dst.len().saturating_sub(1);
+    let bytes = s.as_bytes();
+    let n = bytes.len().min(max);
+    dst[..n].copy_from_slice(&bytes[..n]);
+}
+
+/// Read a NUL-terminated string from a fixed-width field.
+fn read_cstr(src: &[u8]) -> String {
+    let end = src.iter().position(|&c| c == 0).unwrap_or(src.len());
+    String::from_utf8_lossy(&src[..end]).into_owned()
+}
+
+// --- protocol constants (pcsclite.h) -------------------------------------
+
+/// `SCARD_SCOPE_*`.
+pub mod scope {
+    pub const USER: u32 = 0;
+    pub const TERMINAL: u32 = 1;
+    pub const SYSTEM: u32 = 2;
+}
+
+/// `SCARD_SHARE_*`.
+pub mod share {
+    pub const EXCLUSIVE: u32 = 1;
+    pub const SHARED: u32 = 2;
+    pub const DIRECT: u32 = 3;
+}
+
+/// `SCARD_PROTOCOL_*`.
+pub mod protocol {
+    pub const UNDEFINED: u32 = 0;
+    pub const T0: u32 = 1;
+    pub const T1: u32 = 2;
+    pub const RAW: u32 = 4;
+    pub const ANY: u32 = T0 | T1;
+}
+
+/// `SCARD_*_CARD` dispositions (disconnect / end-transaction).
+pub mod disposition {
+    pub const LEAVE: u32 = 0;
+    pub const RESET: u32 = 1;
+    pub const UNPOWER: u32 = 2;
+    pub const EJECT: u32 = 3;
+}
+
+/// Internal `readerState` bit flags (pcsclite.h). These are the
+/// daemon-side state bits stored in `READER_STATE.readerState`, not the
+/// `SCARD_STATE_*` flags the client app sees.
+pub mod reader_flags {
+    pub const UNKNOWN: u32 = 0x0001;
+    pub const ABSENT: u32 = 0x0002;
+    pub const PRESENT: u32 = 0x0004;
+    pub const SWALLOWED: u32 = 0x0008;
+    pub const POWERED: u32 = 0x0010;
+    pub const NEGOTIABLE: u32 = 0x0020;
+    pub const SPECIFIC: u32 = 0x0040;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Codec tests only need the success code; the full SCARD_* vocabulary
+    // lives in error.rs (proto is the lower layer and stays code-free).
+    const SCARD_S_SUCCESS: u32 = 0;
 
     #[test]
     fn header_roundtrips() {
@@ -334,5 +591,75 @@ mod tests {
         assert_eq!(Header::from_bytes(&[0u8; 7]), None);
         assert_eq!(VersionStruct::from_bytes(&[0u8; 11]), None);
         assert_eq!(TransmitStruct::from_bytes(&[0u8; 31]), None);
+    }
+
+    #[test]
+    fn connect_struct_roundtrips_and_is_152_bytes() {
+        let c = ConnectStruct {
+            h_context: 0x0101_0101,
+            sz_reader: "Yubico YubiKey OTP+FIDO+CCID 00 00".to_string(),
+            dw_share_mode: share::SHARED,
+            dw_preferred_protocols: protocol::ANY,
+            h_card: 0,
+            dw_active_protocol: 0,
+            rv: SCARD_S_SUCCESS,
+        };
+        let bytes = c.to_bytes();
+        assert_eq!(bytes.len(), ConnectStruct::WIRE_LEN);
+        assert_eq!(bytes.len(), 152);
+        assert_eq!(ConnectStruct::from_bytes(&bytes), Some(c));
+    }
+
+    #[test]
+    fn reader_state_layout_is_184_bytes_with_atr_padding() {
+        let rs = ReaderState {
+            reader_name: "Virtual PCD piggy fibby 00 00".to_string(),
+            event_counter: 1,
+            reader_state: reader_flags::PRESENT | reader_flags::POWERED | reader_flags::NEGOTIABLE,
+            reader_sharing: 0,
+            card_atr: vec![0x3B, 0xFD, 0x13, 0x00, 0x00, 0x81, 0x31, 0xFE, 0x15, 0x80],
+            card_protocol: protocol::T1,
+        };
+        let bytes = rs.to_bytes();
+        assert_eq!(bytes.len(), 184);
+        // ATR length lands at offset 176 (33-byte ATR field at 140 + 3 pad).
+        assert_eq!(&bytes[176..180], &10u32.to_le_bytes());
+        // cardProtocol at 180.
+        assert_eq!(&bytes[180..184], &protocol::T1.to_le_bytes());
+        assert_eq!(ReaderState::from_bytes(&bytes), Some(rs));
+    }
+
+    #[test]
+    fn readers_state_array_is_fixed_16_slots() {
+        let arr = readers_state_array(&[ReaderState {
+            reader_name: "r".into(),
+            event_counter: 0,
+            reader_state: reader_flags::PRESENT,
+            reader_sharing: 0,
+            card_atr: vec![0x3B],
+            card_protocol: protocol::T1,
+        }]);
+        assert_eq!(arr.len(), MAX_READERS_CONTEXTS * ReaderState::WIRE_LEN);
+        assert_eq!(arr.len(), 16 * 184);
+        // Slot 0 populated, slot 1 zeroed.
+        assert_eq!(ReaderState::from_bytes(&arr[0..184]).unwrap().reader_name, "r");
+        assert_eq!(ReaderState::from_bytes(&arr[184..368]), Some(ReaderState::empty()));
+    }
+
+    #[test]
+    fn handle_codecs_roundtrip() {
+        let a = HandleArgRv { handle: -1, arg: disposition::RESET, rv: 0 };
+        assert_eq!(HandleArgRv::from_bytes(&a.to_bytes()), Some(a));
+        let h = HandleRv { handle: 7, rv: SCARD_S_SUCCESS };
+        assert_eq!(HandleRv::from_bytes(&h.to_bytes()), Some(h));
+    }
+
+    #[test]
+    fn cstr_truncates_and_nul_terminates() {
+        let mut buf = [0xFFu8; 8];
+        write_cstr(&mut buf, "abcdefghijk");
+        assert_eq!(&buf[..7], b"abcdefg"); // 7 chars + reserved NUL slot
+        assert_eq!(buf[7], 0);
+        assert_eq!(read_cstr(&buf), "abcdefg");
     }
 }

--- a/crates/fibby/src/server.rs
+++ b/crates/fibby/src/server.rs
@@ -98,7 +98,11 @@ fn handle_client(mut stream: UnixStream, backend: SharedBackend) -> std::io::Res
     match read_message(&mut stream)? {
         Some((h, body)) if h.command == Command::Version as u32 => {
             let req = VersionStruct::from_bytes(&body);
-            trace::emit(trace::INFO, "conn", &format!("new client; CMD_VERSION {req:?}"));
+            trace::emit(
+                trace::INFO,
+                "conn",
+                &format!("new client; CMD_VERSION {req:?}"),
+            );
             trace::hexdump("rx", &body);
             let client_major = req.map(|v| v.major).unwrap_or(0);
             let rv = if client_major == PROTOCOL_VERSION_MAJOR {
@@ -107,7 +111,9 @@ fn handle_client(mut stream: UnixStream, backend: SharedBackend) -> std::io::Res
                 trace::emit(
                     trace::INFO,
                     "conn",
-                    &format!("version mismatch: client major {client_major} != {PROTOCOL_VERSION_MAJOR}"),
+                    &format!(
+                        "version mismatch: client major {client_major} != {PROTOCOL_VERSION_MAJOR}"
+                    ),
                 );
                 SCARD_E_NO_SERVICE
             };
@@ -146,7 +152,10 @@ fn handle_client(mut stream: UnixStream, backend: SharedBackend) -> std::io::Res
         trace::emit(
             trace::DEBUG,
             "rx",
-            &format!("command={cmd:?} ({:#04x}) size={}", header.command, header.size),
+            &format!(
+                "command={cmd:?} ({:#04x}) size={}",
+                header.command, header.size
+            ),
         );
         trace::hexdump("rx", &body);
 
@@ -172,7 +181,9 @@ fn handle_client(mut stream: UnixStream, backend: SharedBackend) -> std::io::Res
                 trace::emit(
                     trace::INFO,
                     "rx",
-                    &format!("UNIMPLEMENTED command {other:?} — closing. Capture this and extend server::handle_client."),
+                    &format!(
+                        "UNIMPLEMENTED command {other:?} — closing. Capture this and extend server::handle_client."
+                    ),
                 );
                 return Ok(());
             }
@@ -197,7 +208,11 @@ fn establish(stream: &mut UnixStream, body: &[u8], state: &mut ConnState) -> std
         rv: 0,
     });
     let h = state.mint_context();
-    trace::emit(trace::DEBUG, "tx", &format!("ESTABLISH_CONTEXT -> hContext={h}"));
+    trace::emit(
+        trace::DEBUG,
+        "tx",
+        &format!("ESTABLISH_CONTEXT -> hContext={h}"),
+    );
     reply(
         stream,
         &EstablishStruct {
@@ -222,7 +237,11 @@ fn readers_state(stream: &mut UnixStream, backend: &SharedBackend) -> std::io::R
         },
         reader_sharing: 0,
         card_atr: if present { b.atr() } else { Vec::new() },
-        card_protocol: if present { protocol::T1 } else { protocol::UNDEFINED },
+        card_protocol: if present {
+            protocol::T1
+        } else {
+            protocol::UNDEFINED
+        },
     };
     drop(b);
     trace::emit(trace::DEBUG, "tx", &format!("GET_READERS_STATE -> {st:?}"));
@@ -260,7 +279,11 @@ fn connect(
             resp.h_card = -1;
             resp.dw_active_protocol = 0;
             resp.rv = code;
-            trace::emit(trace::DEBUG, "tx", &format!("CONNECT failed rv={code:#010x}"));
+            trace::emit(
+                trace::DEBUG,
+                "tx",
+                &format!("CONNECT failed rv={code:#010x}"),
+            );
         }
     }
     reply(stream, &resp.to_bytes())
@@ -280,14 +303,22 @@ fn reconnect(stream: &mut UnixStream, body: &[u8], backend: &SharedBackend) -> s
         Ok(active) => {
             out[16..20].copy_from_slice(&active.to_le_bytes()); // dwActiveProtocol
             out[20..24].copy_from_slice(&SCARD_S_SUCCESS.to_le_bytes());
-            trace::emit(trace::DEBUG, "tx", &format!("RECONNECT hCard={h_card} proto={active}"));
+            trace::emit(
+                trace::DEBUG,
+                "tx",
+                &format!("RECONNECT hCard={h_card} proto={active}"),
+            );
         }
         Err(code) => out[20..24].copy_from_slice(&code.to_le_bytes()),
     }
     reply(stream, &out)
 }
 
-fn disconnect(stream: &mut UnixStream, body: &[u8], backend: &SharedBackend) -> std::io::Result<()> {
+fn disconnect(
+    stream: &mut UnixStream,
+    body: &[u8],
+    backend: &SharedBackend,
+) -> std::io::Result<()> {
     let req = HandleArgRv::from_bytes(body).unwrap_or(HandleArgRv {
         handle: -1,
         arg: disposition::LEAVE,
@@ -300,7 +331,10 @@ fn disconnect(stream: &mut UnixStream, body: &[u8], backend: &SharedBackend) -> 
     trace::emit(
         trace::DEBUG,
         "tx",
-        &format!("DISCONNECT hCard={} disp={} rv={rv:#010x}", req.handle, req.arg),
+        &format!(
+            "DISCONNECT hCard={} disp={} rv={rv:#010x}",
+            req.handle, req.arg
+        ),
     );
     reply(
         stream,
@@ -358,7 +392,11 @@ fn transmit(
             write_body(stream, &resp)
         }
         Err(code) => {
-            trace::emit(trace::DEBUG, "tx", &format!("TRANSMIT failed rv={code:#010x}"));
+            trace::emit(
+                trace::DEBUG,
+                "tx",
+                &format!("TRANSMIT failed rv={code:#010x}"),
+            );
             let mut reply_struct = req;
             reply_struct.pcb_recv_length = 0;
             reply_struct.rv = code;

--- a/crates/fibby/src/server.rs
+++ b/crates/fibby/src/server.rs
@@ -1,0 +1,446 @@
+//! The pcsc-lite daemon server: listen on a Unix socket, speak the
+//! client protocol, and dispatch each command to a [`Backend`].
+//!
+//! Concurrency model (deliberately simple, easy to debug): one thread
+//! per client connection; a single shared backend behind a `Mutex`.
+//! This is sized for the validation use case — one `pivy-tool`/`piggy`
+//! at a time against one card. Multi-client sharing/transactions are
+//! left as a clearly-marked extension point rather than half-built.
+//!
+//! Wire contract reminder (see `frame.rs`): client→server messages
+//! carry an 8-byte header; server→client replies are bare structs.
+
+use std::collections::HashMap;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use crate::backend::Backend;
+use crate::error::*;
+use crate::frame::{read_message, read_payload, write_body};
+use crate::proto::*;
+use crate::trace;
+
+/// Shared, lockable backend handed to every connection thread.
+pub type SharedBackend = Arc<Mutex<dyn Backend>>;
+
+/// Bind `socket_path` and serve forever. Removes a stale socket file
+/// first and chmods the new one so unprivileged clients can connect
+/// (mirrors pcscd's 0777 on `pcscd.comm`).
+pub fn serve(socket_path: &str, backend: SharedBackend) -> std::io::Result<()> {
+    let path = Path::new(socket_path);
+    if path.exists() {
+        std::fs::remove_file(path)?;
+    }
+    let listener = UnixListener::bind(path)?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o777))?;
+    trace::emit(
+        trace::INFO,
+        "listen",
+        &format!("fibby listening on {socket_path} (point PCSCLITE_CSOCK_NAME here)"),
+    );
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                let backend = Arc::clone(&backend);
+                thread::spawn(move || {
+                    if let Err(e) = handle_client(stream, backend) {
+                        trace::emit(trace::INFO, "conn", &format!("connection ended: {e}"));
+                    }
+                });
+            }
+            Err(e) => trace::emit(trace::INFO, "listen", &format!("accept error: {e}")),
+        }
+    }
+    Ok(())
+}
+
+/// Per-connection handle bookkeeping. Handles are minted monotonically;
+/// we record them so a stray handle is visible in logs, but the
+/// single-backend model doesn't multiplex by handle yet.
+struct ConnState {
+    next_context: u32,
+    next_card: i32,
+    contexts: HashMap<u32, ()>,
+    card_protocols: HashMap<i32, u32>,
+}
+
+impl ConnState {
+    fn new() -> Self {
+        ConnState {
+            next_context: 1,
+            next_card: 1,
+            contexts: HashMap::new(),
+            card_protocols: HashMap::new(),
+        }
+    }
+    fn mint_context(&mut self) -> u32 {
+        let h = self.next_context;
+        self.next_context += 1;
+        self.contexts.insert(h, ());
+        h
+    }
+    fn mint_card(&mut self, protocol: u32) -> i32 {
+        let h = self.next_card;
+        self.next_card += 1;
+        self.card_protocols.insert(h, protocol);
+        h
+    }
+}
+
+fn handle_client(mut stream: UnixStream, backend: SharedBackend) -> std::io::Result<()> {
+    // 1) CMD_VERSION handshake. Must come first; a version-major
+    //    mismatch is the sole cause of SCARD_E_SERVICE_STOPPED.
+    match read_message(&mut stream)? {
+        Some((h, body)) if h.command == Command::Version as u32 => {
+            let req = VersionStruct::from_bytes(&body);
+            trace::emit(trace::INFO, "conn", &format!("new client; CMD_VERSION {req:?}"));
+            trace::hexdump("rx", &body);
+            let client_major = req.map(|v| v.major).unwrap_or(0);
+            let rv = if client_major == PROTOCOL_VERSION_MAJOR {
+                SCARD_S_SUCCESS
+            } else {
+                trace::emit(
+                    trace::INFO,
+                    "conn",
+                    &format!("version mismatch: client major {client_major} != {PROTOCOL_VERSION_MAJOR}"),
+                );
+                SCARD_E_NO_SERVICE
+            };
+            let resp = VersionStruct {
+                major: PROTOCOL_VERSION_MAJOR,
+                minor: PROTOCOL_VERSION_MINOR,
+                rv,
+            };
+            reply(&mut stream, &resp.to_bytes())?;
+            if rv != SCARD_S_SUCCESS {
+                return Ok(());
+            }
+        }
+        Some((h, _)) => {
+            trace::emit(
+                trace::INFO,
+                "conn",
+                &format!("expected CMD_VERSION first, got command {:#04x}", h.command),
+            );
+            return Ok(());
+        }
+        None => return Ok(()), // client hung up before handshake
+    }
+
+    // 2) Command loop.
+    let mut state = ConnState::new();
+    loop {
+        let (header, body) = match read_message(&mut stream)? {
+            Some(m) => m,
+            None => {
+                trace::emit(trace::DEBUG, "conn", "client disconnected");
+                return Ok(());
+            }
+        };
+        let cmd = Command::from_u32(header.command);
+        trace::emit(
+            trace::DEBUG,
+            "rx",
+            &format!("command={cmd:?} ({:#04x}) size={}", header.command, header.size),
+        );
+        trace::hexdump("rx", &body);
+
+        match cmd {
+            Some(Command::EstablishContext) => establish(&mut stream, &body, &mut state)?,
+            Some(Command::ReleaseContext) => simple_ok(&mut stream, &body)?,
+            Some(Command::GetReadersState) => readers_state(&mut stream, &backend)?,
+            Some(Command::Connect) => connect(&mut stream, &body, &mut state, &backend)?,
+            Some(Command::Reconnect) => reconnect(&mut stream, &body, &backend)?,
+            Some(Command::Disconnect) => disconnect(&mut stream, &body, &backend)?,
+            Some(Command::BeginTransaction) => begin_end_ok(&mut stream, &body)?,
+            Some(Command::EndTransaction) => end_transaction(&mut stream, &body)?,
+            Some(Command::Transmit) => transmit(&mut stream, &body, &state, &backend)?,
+            Some(Command::Status) => status(&mut stream, &body)?,
+            Some(Command::Cancel) => cancel(&mut stream, &body)?,
+            Some(Command::WaitReaderStateChange) => wait_reader_state(&mut stream, &body)?,
+            // Known commands fibby doesn't speak yet. Closing the
+            // connection here is intentional: it makes the unimplemented
+            // command loudly visible in the log so a wet-env agent knows
+            // exactly what to add next, rather than silently mis-replying
+            // with a wrong-sized struct.
+            Some(other) => {
+                trace::emit(
+                    trace::INFO,
+                    "rx",
+                    &format!("UNIMPLEMENTED command {other:?} — closing. Capture this and extend server::handle_client."),
+                );
+                return Ok(());
+            }
+            None => {
+                trace::emit(
+                    trace::INFO,
+                    "rx",
+                    &format!("unknown command {:#04x} — closing", header.command),
+                );
+                return Ok(());
+            }
+        }
+    }
+}
+
+// --- command handlers ----------------------------------------------------
+
+fn establish(stream: &mut UnixStream, body: &[u8], state: &mut ConnState) -> std::io::Result<()> {
+    let req = EstablishStruct::from_bytes(body).unwrap_or(EstablishStruct {
+        dw_scope: scope::SYSTEM,
+        h_context: 0,
+        rv: 0,
+    });
+    let h = state.mint_context();
+    trace::emit(trace::DEBUG, "tx", &format!("ESTABLISH_CONTEXT -> hContext={h}"));
+    reply(
+        stream,
+        &EstablishStruct {
+            dw_scope: req.dw_scope,
+            h_context: h,
+            rv: SCARD_S_SUCCESS,
+        }
+        .to_bytes(),
+    )
+}
+
+fn readers_state(stream: &mut UnixStream, backend: &SharedBackend) -> std::io::Result<()> {
+    let b = backend.lock().unwrap();
+    let present = b.card_present();
+    let st = ReaderState {
+        reader_name: b.reader_name(),
+        event_counter: 0,
+        reader_state: if present {
+            reader_flags::PRESENT | reader_flags::POWERED | reader_flags::NEGOTIABLE
+        } else {
+            reader_flags::ABSENT
+        },
+        reader_sharing: 0,
+        card_atr: if present { b.atr() } else { Vec::new() },
+        card_protocol: if present { protocol::T1 } else { protocol::UNDEFINED },
+    };
+    drop(b);
+    trace::emit(trace::DEBUG, "tx", &format!("GET_READERS_STATE -> {st:?}"));
+    reply(stream, &readers_state_array(&[st]))
+}
+
+fn connect(
+    stream: &mut UnixStream,
+    body: &[u8],
+    state: &mut ConnState,
+    backend: &SharedBackend,
+) -> std::io::Result<()> {
+    let req = match ConnectStruct::from_bytes(body) {
+        Some(r) => r,
+        None => return reply_handle_rv(stream, -1, SCARD_E_INVALID_VALUE),
+    };
+    let mut resp = req.clone();
+    match backend
+        .lock()
+        .unwrap()
+        .connect(req.dw_share_mode, req.dw_preferred_protocols)
+    {
+        Ok(active) => {
+            let h = state.mint_card(active);
+            resp.h_card = h;
+            resp.dw_active_protocol = active;
+            resp.rv = SCARD_S_SUCCESS;
+            trace::emit(
+                trace::DEBUG,
+                "tx",
+                &format!("CONNECT '{}' -> hCard={h} proto={active}", req.sz_reader),
+            );
+        }
+        Err(code) => {
+            resp.h_card = -1;
+            resp.dw_active_protocol = 0;
+            resp.rv = code;
+            trace::emit(trace::DEBUG, "tx", &format!("CONNECT failed rv={code:#010x}"));
+        }
+    }
+    reply(stream, &resp.to_bytes())
+}
+
+fn reconnect(stream: &mut UnixStream, body: &[u8], backend: &SharedBackend) -> std::io::Result<()> {
+    // reconnect_struct { i32 hCard; u32 dwShareMode; u32 dwPreferredProtocols;
+    //                    u32 dwInitialization; u32 dwActiveProtocol; u32 rv }
+    let r = |o: usize| u32::from_le_bytes(body[o..o + 4].try_into().unwrap());
+    if body.len() < 24 {
+        return reply(stream, body); // echo; malformed
+    }
+    let h_card = i32::from_le_bytes(body[0..4].try_into().unwrap());
+    let (share, preferred) = (r(4), r(8));
+    let mut out = body.to_vec();
+    match backend.lock().unwrap().connect(share, preferred) {
+        Ok(active) => {
+            out[16..20].copy_from_slice(&active.to_le_bytes()); // dwActiveProtocol
+            out[20..24].copy_from_slice(&SCARD_S_SUCCESS.to_le_bytes());
+            trace::emit(trace::DEBUG, "tx", &format!("RECONNECT hCard={h_card} proto={active}"));
+        }
+        Err(code) => out[20..24].copy_from_slice(&code.to_le_bytes()),
+    }
+    reply(stream, &out)
+}
+
+fn disconnect(stream: &mut UnixStream, body: &[u8], backend: &SharedBackend) -> std::io::Result<()> {
+    let req = HandleArgRv::from_bytes(body).unwrap_or(HandleArgRv {
+        handle: -1,
+        arg: disposition::LEAVE,
+        rv: 0,
+    });
+    let rv = match backend.lock().unwrap().disconnect(req.arg) {
+        Ok(()) => SCARD_S_SUCCESS,
+        Err(code) => code,
+    };
+    trace::emit(
+        trace::DEBUG,
+        "tx",
+        &format!("DISCONNECT hCard={} disp={} rv={rv:#010x}", req.handle, req.arg),
+    );
+    reply(
+        stream,
+        &HandleArgRv {
+            handle: req.handle,
+            arg: req.arg,
+            rv,
+        }
+        .to_bytes(),
+    )
+}
+
+fn transmit(
+    stream: &mut UnixStream,
+    body: &[u8],
+    state: &ConnState,
+    backend: &SharedBackend,
+) -> std::io::Result<()> {
+    let req = match TransmitStruct::from_bytes(body) {
+        Some(r) => r,
+        None => return Ok(()),
+    };
+    // The send APDU streams right after the fixed struct (no header), on
+    // the same connection.
+    let apdu = read_payload(stream, req.cb_send_length as usize)?;
+    trace::emit(
+        trace::DEBUG,
+        "rx",
+        &format!("TRANSMIT hCard={} {} bytes", req.h_card, apdu.len()),
+    );
+    trace::hexdump("apdu>", &apdu);
+
+    let result = backend.lock().unwrap().transmit(&apdu);
+    let active = state
+        .card_protocols
+        .get(&req.h_card)
+        .copied()
+        .unwrap_or(protocol::T1);
+
+    match result {
+        Ok(resp) => {
+            trace::hexdump("apdu<", &resp);
+            let reply_struct = TransmitStruct {
+                h_card: req.h_card,
+                io_send_pci_protocol: req.io_send_pci_protocol,
+                io_send_pci_length: req.io_send_pci_length,
+                cb_send_length: req.cb_send_length,
+                io_recv_pci_protocol: active,
+                io_recv_pci_length: 8, // sizeof(SCARD_IO_REQUEST)
+                pcb_recv_length: resp.len() as u32,
+                rv: SCARD_S_SUCCESS,
+            };
+            trace::hexdump("tx", &reply_struct.to_bytes());
+            write_body(stream, &reply_struct.to_bytes())?;
+            write_body(stream, &resp)
+        }
+        Err(code) => {
+            trace::emit(trace::DEBUG, "tx", &format!("TRANSMIT failed rv={code:#010x}"));
+            let mut reply_struct = req;
+            reply_struct.pcb_recv_length = 0;
+            reply_struct.rv = code;
+            write_body(stream, &reply_struct.to_bytes())
+        }
+    }
+}
+
+fn status(stream: &mut UnixStream, body: &[u8]) -> std::io::Result<()> {
+    // SCardStatus fills reader name / state / ATR client-side from the
+    // cached reader-state array; the round-trip only needs hCard + rv.
+    // Wet-env: if a client expects more here, capture and extend.
+    let req = HandleRv::from_bytes(body).unwrap_or(HandleRv { handle: -1, rv: 0 });
+    reply_handle_rv(stream, req.handle, SCARD_S_SUCCESS)
+}
+
+fn cancel(stream: &mut UnixStream, body: &[u8]) -> std::io::Result<()> {
+    let req = HandleRv::from_bytes(body).unwrap_or(HandleRv { handle: -1, rv: 0 });
+    reply_handle_rv(stream, req.handle, SCARD_S_SUCCESS)
+}
+
+fn begin_end_ok(stream: &mut UnixStream, body: &[u8]) -> std::io::Result<()> {
+    // BEGIN_TRANSACTION: single-client model grants unconditionally.
+    let req = HandleRv::from_bytes(body).unwrap_or(HandleRv { handle: -1, rv: 0 });
+    reply_handle_rv(stream, req.handle, SCARD_S_SUCCESS)
+}
+
+fn end_transaction(stream: &mut UnixStream, body: &[u8]) -> std::io::Result<()> {
+    let req = HandleArgRv::from_bytes(body).unwrap_or(HandleArgRv {
+        handle: -1,
+        arg: disposition::LEAVE,
+        rv: 0,
+    });
+    reply(
+        stream,
+        &HandleArgRv {
+            handle: req.handle,
+            arg: req.arg,
+            rv: SCARD_S_SUCCESS,
+        }
+        .to_bytes(),
+    )
+}
+
+fn wait_reader_state(stream: &mut UnixStream, body: &[u8]) -> std::io::Result<()> {
+    // wait_reader_state_change { u32 timeOut; u32 rv }. Our card state
+    // is static, so honor the timeout (capped) then report success so
+    // the client re-reads states without busy-spinning. Wet-env: real
+    // hot-plug needs an event source here.
+    let timeout_ms = if body.len() >= 4 {
+        u32::from_le_bytes(body[0..4].try_into().unwrap())
+    } else {
+        0
+    };
+    let capped = timeout_ms.min(1_000);
+    if capped > 0 {
+        thread::sleep(Duration::from_millis(capped as u64));
+    }
+    let mut out = [0u8; 8];
+    out[0..4].copy_from_slice(&timeout_ms.to_le_bytes());
+    out[4..8].copy_from_slice(&SCARD_S_SUCCESS.to_le_bytes());
+    reply(stream, &out)
+}
+
+/// ReleaseContext-style: echo the request body with a success rv in its
+/// last 4 bytes.
+fn simple_ok(stream: &mut UnixStream, body: &[u8]) -> std::io::Result<()> {
+    let mut out = body.to_vec();
+    let n = out.len();
+    if n >= 4 {
+        out[n - 4..].copy_from_slice(&SCARD_S_SUCCESS.to_le_bytes());
+    }
+    reply(stream, &out)
+}
+
+// --- small helpers -------------------------------------------------------
+
+fn reply(stream: &mut UnixStream, body: &[u8]) -> std::io::Result<()> {
+    trace::hexdump("tx", body);
+    write_body(stream, body)
+}
+
+fn reply_handle_rv(stream: &mut UnixStream, handle: i32, rv: u32) -> std::io::Result<()> {
+    reply(stream, &HandleRv { handle, rv }.to_bytes())
+}

--- a/crates/fibby/src/trace.rs
+++ b/crates/fibby/src/trace.rs
@@ -1,0 +1,79 @@
+//! Lightweight, dependency-free leveled logging + hex dumping.
+//!
+//! The whole point of fibby is to be debugged against real hardware by
+//! other agents, so wire visibility is a feature, not an afterthought.
+//! Control verbosity with the `FIBBY_LOG` env var:
+//!
+//! ```text
+//! FIBBY_LOG=info    connection lifecycle, one line per command
+//! FIBBY_LOG=debug   + decoded struct fields
+//! FIBBY_LOG=wire    + full hex dump of every rx/tx body (the firehose)
+//! ```
+//!
+//! Everything goes to stderr with a `[fibby:<tag>]` prefix so it
+//! interleaves cleanly with `pivy-tool`/`pcscd` output during a capture.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+
+pub const OFF: u8 = 0;
+pub const INFO: u8 = 1;
+pub const DEBUG: u8 = 2;
+pub const WIRE: u8 = 3;
+
+static LEVEL: AtomicU8 = AtomicU8::new(OFF);
+
+/// Read `FIBBY_LOG` once at startup. Unknown values default to `info`.
+pub fn init_from_env() {
+    let lvl = match std::env::var("FIBBY_LOG").ok().as_deref() {
+        Some("off") | None => OFF,
+        Some("info") => INFO,
+        Some("debug") => DEBUG,
+        Some("wire") | Some("trace") => WIRE,
+        Some(_) => INFO,
+    };
+    LEVEL.store(lvl, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn level() -> u8 {
+    LEVEL.load(Ordering::Relaxed)
+}
+
+#[inline]
+pub fn enabled(lvl: u8) -> bool {
+    level() >= lvl
+}
+
+/// Emit one log line at `lvl` if enabled. `tag` is a short subsystem
+/// label (e.g. "conn", "rx", "tx", "proxy").
+pub fn emit(lvl: u8, tag: &str, msg: &str) {
+    if enabled(lvl) {
+        eprintln!("[fibby:{tag}] {msg}");
+    }
+}
+
+/// Hex dump in the canonical `offset  hex…  |ascii|` form, only built
+/// when the WIRE level is active (so the formatting cost is skipped
+/// otherwise).
+pub fn hexdump(tag: &str, bytes: &[u8]) {
+    if !enabled(WIRE) {
+        return;
+    }
+    if bytes.is_empty() {
+        eprintln!("[fibby:{tag}] <empty>");
+        return;
+    }
+    for (i, chunk) in bytes.chunks(16).enumerate() {
+        let mut hex = String::with_capacity(48);
+        let mut asc = String::with_capacity(16);
+        for b in chunk {
+            hex.push_str(&format!("{b:02x} "));
+            asc.push(if b.is_ascii_graphic() || *b == b' ' {
+                *b as char
+            } else {
+                '.'
+            });
+        }
+        eprintln!("[fibby:{tag}] {:04x}  {:<48} |{}|", i * 16, hex, asc);
+    }
+}

--- a/crates/fibby/src/virtual_card.rs
+++ b/crates/fibby/src/virtual_card.rs
@@ -1,0 +1,165 @@
+//! `VirtualCard` — the in-Rust card behind fibby's reader.
+//!
+//! **Status: stub.** This exists to bring the pcsc-lite protocol path
+//! up end-to-end (a client can ESTABLISH → CONNECT → TRANSMIT SELECT →
+//! DISCONNECT against fibby with no pcscd). The real PIV applet —
+//! GENERATE ASYMMETRIC, GENERAL AUTHENTICATE (sign + ECDH), GET/PUT
+//! DATA, VERIFY PIN, YubiKey attestation/serial — is phase-5 work in
+//! docs/plans/2026-05-29-fibby-virtual-piv-rust-design.md, validated
+//! against RFC 0002 Appendix A and SP 800-73-4 vectors.
+//!
+//! Until then, SELECT of the PIV AID succeeds (so `pivy-tool list` /
+//! readiness probes see a live PIV card) and every other instruction
+//! returns `6D00` (INS not supported). Keep the stub honest: it must
+//! never *look* like it did crypto it didn't.
+
+use crate::apdu;
+use crate::backend::{Backend, ScardResult};
+use crate::proto::protocol;
+use crate::trace;
+
+/// A real YubiKey 5 PIV ATR (contains the ASCII "YubiKey"). Placeholder:
+/// the wet-env capture should replace this with the exact ATR the target
+/// model reports, taken from the hardware-proxy backend's `atr()`.
+const YUBIKEY5_ATR: &[u8] = &[
+    0x3B, 0xFD, 0x13, 0x00, 0x00, 0x81, 0x31, 0xFE, 0x15, 0x80, 0x73, 0xC0, 0x21, 0xC0, 0x57, 0x59,
+    0x75, 0x62, 0x69, 0x4B, 0x65, 0x79, 0x40,
+];
+
+pub struct VirtualCard {
+    reader_name: String,
+    powered: bool,
+    selected_piv: bool,
+}
+
+impl Default for VirtualCard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VirtualCard {
+    pub fn new() -> Self {
+        VirtualCard {
+            reader_name: "Virtual PCD piggy fibby 00 00".to_string(),
+            powered: false,
+            selected_piv: false,
+        }
+    }
+}
+
+impl Backend for VirtualCard {
+    fn reader_name(&self) -> String {
+        self.reader_name.clone()
+    }
+
+    fn card_present(&self) -> bool {
+        true // the virtual card is always inserted
+    }
+
+    fn atr(&self) -> Vec<u8> {
+        YUBIKEY5_ATR.to_vec()
+    }
+
+    fn connect(&mut self, _share_mode: u32, _preferred_protocols: u32) -> ScardResult<u32> {
+        self.powered = true;
+        self.selected_piv = false;
+        Ok(protocol::T1)
+    }
+
+    fn disconnect(&mut self, _disposition: u32) -> ScardResult<()> {
+        self.powered = false;
+        self.selected_piv = false;
+        Ok(())
+    }
+
+    fn transmit(&mut self, command_apdu: &[u8]) -> ScardResult<Vec<u8>> {
+        if command_apdu.len() < 4 {
+            return Ok(sw(0x6F, 0x00)); // no precise diagnosis
+        }
+        let (cla, ins, p1, p2) = (
+            command_apdu[0],
+            command_apdu[1],
+            command_apdu[2],
+            command_apdu[3],
+        );
+
+        // SELECT (00 A4 04 00 <Lc> <AID>) of the PIV application.
+        if cla == 0x00 && ins == apdu::ins::SELECT && p1 == 0x04 && p2 == 0x00 {
+            let aid = command_apdu.get(5..).unwrap_or(&[]);
+            let lc = command_apdu.get(4).copied().unwrap_or(0) as usize;
+            let aid = aid.get(..lc.min(aid.len())).unwrap_or(aid);
+            if aid.starts_with(apdu::PIV_AID_PREFIX) {
+                self.selected_piv = true;
+                trace::emit(trace::DEBUG, "vcard", "SELECT PIV AID -> 9000 (stub FCI)");
+                let mut resp = piv_select_fci();
+                resp.extend_from_slice(&sw(0x90, 0x00));
+                return Ok(resp);
+            }
+            trace::emit(trace::DEBUG, "vcard", "SELECT non-PIV AID -> 6A82");
+            return Ok(sw(0x6A, 0x82)); // file/application not found
+        }
+
+        trace::emit(
+            trace::DEBUG,
+            "vcard",
+            &format!("unimplemented INS {ins:#04x} -> 6D00 (stub)"),
+        );
+        Ok(sw(0x6D, 0x00)) // instruction not supported (yet)
+    }
+}
+
+/// Minimal PIV application property template (tag 0x61) naming the PIV
+/// AID, enough for a client's SELECT to parse. Not a full SP 800-73-4
+/// FCI — the real applet emits the algorithm list etc.
+fn piv_select_fci() -> Vec<u8> {
+    // 61 <len> 4F <len> <AID full> 79 <len> 4F <len> <AID prefix>
+    let mut inner = Vec::new();
+    inner.push(0x4F);
+    inner.push(apdu::PIV_AID.len() as u8);
+    inner.extend_from_slice(apdu::PIV_AID);
+    let mut out = vec![0x61, inner.len() as u8];
+    out.extend_from_slice(&inner);
+    out
+}
+
+#[inline]
+fn sw(sw1: u8, sw2: u8) -> Vec<u8> {
+    vec![sw1, sw2]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn select_piv() -> Vec<u8> {
+        let mut a = vec![0x00, 0xA4, 0x04, 0x00, apdu::PIV_AID.len() as u8];
+        a.extend_from_slice(apdu::PIV_AID);
+        a
+    }
+
+    #[test]
+    fn connect_then_select_piv_succeeds() {
+        let mut c = VirtualCard::new();
+        assert_eq!(c.connect(2, 3), Ok(protocol::T1));
+        let resp = c.transmit(&select_piv()).unwrap();
+        assert_eq!(&resp[resp.len() - 2..], &[0x90, 0x00]);
+        assert_eq!(resp[0], 0x61); // application property template
+    }
+
+    #[test]
+    fn unknown_instruction_is_6d00() {
+        let mut c = VirtualCard::new();
+        let resp = c.transmit(&[0x00, 0x47, 0x00, 0x9D]).unwrap();
+        assert_eq!(resp, vec![0x6D, 0x00]);
+    }
+
+    #[test]
+    fn atr_is_present_and_yubikey_flavored() {
+        let c = VirtualCard::new();
+        assert!(c.card_present());
+        let atr = c.atr();
+        assert_eq!(atr[0], 0x3B); // direct convention TS byte
+        assert!(atr.windows(7).any(|w| w == b"YubiKey"));
+    }
+}

--- a/crates/fibby/tests/loopback.rs
+++ b/crates/fibby/tests/loopback.rs
@@ -40,11 +40,17 @@ impl Client {
 }
 
 fn unique_socket_path() -> std::path::PathBuf {
+    // AF_UNIX sun_path is 108 bytes on Linux / 104 on macOS. Some test
+    // environments (spinclass worktree TMPDIR = `<repo>/.worktrees/<name>/.tmp`)
+    // push `std::env::temp_dir()` past ~56 chars on its own, enough that the
+    // PID+nanos suffix overflows sun_path and `bind()` fails silently. /tmp
+    // is short and writable in every environment this test runs in — host
+    // devshell, nix sandbox (private /tmp), GitHub Actions.
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    std::env::temp_dir().join(format!("fibby-loopback-{}-{}.sock", std::process::id(), nanos))
+    std::path::PathBuf::from("/tmp").join(format!("fibby-{}-{}.sock", std::process::id(), nanos))
 }
 
 fn start_server(path: &std::path::Path) {
@@ -102,7 +108,11 @@ fn full_piv_select_session_over_socket() {
     let arr = c.recv(MAX_READERS_CONTEXTS * ReaderState::WIRE_LEN);
     let slot0 = ReaderState::from_bytes(&arr[0..ReaderState::WIRE_LEN]).unwrap();
     assert!(slot0.reader_name.contains("fibby"), "reader advertised");
-    assert_ne!(slot0.reader_state & reader_flags::PRESENT, 0, "card present");
+    assert_ne!(
+        slot0.reader_state & reader_flags::PRESENT,
+        0,
+        "card present"
+    );
     assert!(!slot0.card_atr.is_empty(), "ATR reported");
 
     // 4) CONNECT.

--- a/crates/fibby/tests/loopback.rs
+++ b/crates/fibby/tests/loopback.rs
@@ -1,0 +1,168 @@
+//! End-to-end loopback: a real client UnixStream drives fibby's server
+//! (with the `VirtualCard` backend) through a full PC/SC session over a
+//! real socket — no pcscd, no hardware. This is the hermetic
+//! cross-check of the protocol layer and the template the wet-env
+//! agents extend (swap in the hardware-proxy backend, replay the same
+//! script, diff the bytes).
+
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use fibby::proto::*;
+use fibby::server;
+use fibby::virtual_card::VirtualCard;
+
+/// Minimal client: write `rxHeader + body`, read a bare reply of a known
+/// size (server replies carry no header).
+struct Client {
+    stream: UnixStream,
+}
+
+impl Client {
+    fn send(&mut self, command: Command, body: &[u8]) {
+        let header = Header {
+            size: body.len() as u32,
+            command: command as u32,
+        };
+        self.stream.write_all(&header.to_bytes()).unwrap();
+        self.stream.write_all(body).unwrap();
+        self.stream.flush().unwrap();
+    }
+
+    fn recv(&mut self, n: usize) -> Vec<u8> {
+        let mut buf = vec![0u8; n];
+        self.stream.read_exact(&mut buf).unwrap();
+        buf
+    }
+}
+
+fn unique_socket_path() -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("fibby-loopback-{}-{}.sock", std::process::id(), nanos))
+}
+
+fn start_server(path: &std::path::Path) {
+    let backend = Arc::new(Mutex::new(VirtualCard::new()));
+    let serve_path = path.to_path_buf();
+    thread::spawn(move || {
+        let _ = server::serve(serve_path.to_str().unwrap(), backend);
+    });
+    // Wait for the socket to appear.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !path.exists() {
+        assert!(Instant::now() < deadline, "server socket never appeared");
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn full_piv_select_session_over_socket() {
+    let path = unique_socket_path();
+    start_server(&path);
+    let mut c = Client {
+        stream: UnixStream::connect(&path).unwrap(),
+    };
+
+    // 1) CMD_VERSION handshake.
+    c.send(
+        Command::Version,
+        &VersionStruct {
+            major: PROTOCOL_VERSION_MAJOR,
+            minor: PROTOCOL_VERSION_MINOR,
+            rv: 0,
+        }
+        .to_bytes(),
+    );
+    let ver = VersionStruct::from_bytes(&c.recv(VersionStruct::WIRE_LEN)).unwrap();
+    assert_eq!(ver.major, PROTOCOL_VERSION_MAJOR);
+    assert_eq!(ver.rv, 0, "handshake should succeed");
+
+    // 2) ESTABLISH_CONTEXT.
+    c.send(
+        Command::EstablishContext,
+        &EstablishStruct {
+            dw_scope: scope::SYSTEM,
+            h_context: 0,
+            rv: 0,
+        }
+        .to_bytes(),
+    );
+    let est = EstablishStruct::from_bytes(&c.recv(EstablishStruct::WIRE_LEN)).unwrap();
+    assert_eq!(est.rv, 0);
+    assert!(est.h_context > 0, "minted a context handle");
+
+    // 3) GET_READERS_STATE (no body) — fixed 16-slot array.
+    c.send(Command::GetReadersState, &[]);
+    let arr = c.recv(MAX_READERS_CONTEXTS * ReaderState::WIRE_LEN);
+    let slot0 = ReaderState::from_bytes(&arr[0..ReaderState::WIRE_LEN]).unwrap();
+    assert!(slot0.reader_name.contains("fibby"), "reader advertised");
+    assert_ne!(slot0.reader_state & reader_flags::PRESENT, 0, "card present");
+    assert!(!slot0.card_atr.is_empty(), "ATR reported");
+
+    // 4) CONNECT.
+    c.send(
+        Command::Connect,
+        &ConnectStruct {
+            h_context: est.h_context,
+            sz_reader: slot0.reader_name.clone(),
+            dw_share_mode: share::SHARED,
+            dw_preferred_protocols: protocol::ANY,
+            h_card: 0,
+            dw_active_protocol: 0,
+            rv: 0,
+        }
+        .to_bytes(),
+    );
+    let con = ConnectStruct::from_bytes(&c.recv(ConnectStruct::WIRE_LEN)).unwrap();
+    assert_eq!(con.rv, 0);
+    assert!(con.h_card > 0, "minted a card handle");
+    assert_eq!(con.dw_active_protocol, protocol::T1);
+
+    // 5) TRANSMIT a PIV SELECT and read the response (struct + buffer).
+    let piv_aid: &[u8] = &[
+        0xA0, 0x00, 0x00, 0x03, 0x08, 0x00, 0x00, 0x10, 0x00, 0x01, 0x00,
+    ];
+    let mut apdu = vec![0x00, 0xA4, 0x04, 0x00, piv_aid.len() as u8];
+    apdu.extend_from_slice(piv_aid);
+    let tx = TransmitStruct {
+        h_card: con.h_card,
+        io_send_pci_protocol: protocol::T1,
+        io_send_pci_length: 8,
+        cb_send_length: apdu.len() as u32,
+        io_recv_pci_protocol: 0,
+        io_recv_pci_length: 0,
+        pcb_recv_length: 258,
+        rv: 0,
+    };
+    // header(size=32) + struct, then the APDU buffer (no header).
+    c.send(Command::Transmit, &tx.to_bytes());
+    c.stream.write_all(&apdu).unwrap();
+    c.stream.flush().unwrap();
+
+    let reply = TransmitStruct::from_bytes(&c.recv(TransmitStruct::WIRE_LEN)).unwrap();
+    assert_eq!(reply.rv, 0, "transmit succeeded");
+    let resp = c.recv(reply.pcb_recv_length as usize);
+    assert!(resp.len() >= 2);
+    assert_eq!(&resp[resp.len() - 2..], &[0x90, 0x00], "SELECT -> 9000");
+
+    // 6) DISCONNECT (LEAVE).
+    c.send(
+        Command::Disconnect,
+        &HandleArgRv {
+            handle: con.h_card,
+            arg: disposition::LEAVE,
+            rv: 0,
+        }
+        .to_bytes(),
+    );
+    let dis = HandleArgRv::from_bytes(&c.recv(HandleArgRv::WIRE_LEN)).unwrap();
+    assert_eq!(dis.rv, 0);
+
+    let _ = std::fs::remove_file(&path);
+}

--- a/docs/plans/2026-05-29-fibby-virtual-piv-rust-design.md
+++ b/docs/plans/2026-05-29-fibby-virtual-piv-rust-design.md
@@ -443,25 +443,51 @@ The web/cloud session container has `libpcsclite.so.1` at runtime but
   backend and the end-to-end proxy validation. That leg is operator-
   driven (`cargo run -p fibby --features hardware-proxy`).
 
-### Landed in this pass
+### Landed (steps 1–3 complete)
 
-- `crates/fibby` added to the workspace.
-- `proto.rs`: protocol constants (v4.6), the full `Command` enum with
-  wire values, and codecs for `rxHeader`, `version_struct`,
-  `establish_struct`, `transmit_struct`, plus a little-endian-host
-  assertion. 6 unit tests, all green (`cargo test -p fibby
-  --no-default-features`).
+Full protocol server + both backends + hermetic end-to-end coverage:
+
+- `proto.rs` — protocol 4.6 codec: `Command` enum, `rxHeader` framing,
+  and codecs for version / establish / connect / transmit / disconnect /
+  reader-state structs, plus the 184-byte `READER_STATE` array (ATR
+  padding included) and the protocol constants
+  (scope/share/protocol/disposition/reader-flags).
+- `frame.rs` — message framing with the client↔server asymmetry made
+  explicit (header-in / bare-out / streamed TRANSMIT payload), oversize
+  guard, clean-EOF detection.
+- `error.rs` — `SCARD_*` codes. `trace.rs` — `FIBBY_LOG` leveled logging
+  + hex dumps.
+- `backend.rs` — the `Backend` trait. `virtual_card.rs` — stub PIV card
+  (SELECT→9000, else 6D00). `hardware_proxy.rs` — real-pcscd proxy via
+  the `pcsc` crate (feature `hardware-proxy`).
+- `server.rs` — listen loop, `CMD_VERSION` handshake, handle table,
+  dispatch for the full common command set; unimplemented commands are
+  logged loudly and close the connection (no silent mis-replies).
+- `main.rs` — CLI (`--socket`/`--backend`/`--reader`).
+- Tests: 17 unit + `tests/loopback.rs` (full PC/SC session over a real
+  socket against `VirtualCard`), all green via
+  `cargo test -p fibby --no-default-features`.
+- `crates/fibby/README.md` — module map, `FIBBY_LOG` guide, and the
+  hardware-validation runbook for the wet-env pass.
 
 ### Next steps
 
-1. Flesh out the remaining `*_struct` codecs (connect/reconnect/
-   disconnect/status/get-status-change + the `READER_STATE` array).
-2. Server event loop: Unix-socket listener, `CMD_VERSION` handshake,
-   context/card handle table, command dispatch to a `Backend`.
-3. `Backend` trait + `HardwareProxy` (via `pcsc` crate) + a stub
-   `VirtualCard` (fixed ATR, SELECT echo).
-4. **Capture/validate:** point `pivy-tool list`/`generate 9d` at fibby
-   with the HardwareProxy backend on a machine with a YubiKey; record
-   the wire traffic as conformance fixtures.
-5. Grow `VirtualCard` into the real PIV applet (phases 2–3 above) and
-   replay the captured fixtures against it.
+4. **Capture/validate (wet-env, needs a YubiKey):** run fibby with the
+   `hardware-proxy` backend, point `pivy-tool list`/`generate 9d` at its
+   socket, and record the `FIBBY_LOG=wire` traffic as conformance
+   fixtures. The proxy also reveals any command fibby doesn't yet speak
+   (logged UNIMPLEMENTED with the body hex).
+5. Grow `VirtualCard` into the real PIV applet (GENERATE / GENERAL
+   AUTHENTICATE sign+ECDH / GET·PUT DATA / VERIFY / YubiKey
+   attestation+serial) and replay the captured fixtures + RFC 0002
+   Appendix A + SP 800-73-4 vectors against it.
+6. Swap the bats/conformance test path onto fibby; keep `fib` as a
+   differential oracle for one release.
+
+### Build-environment note
+
+The cloud session container has `libpcsclite.so.1` but no
+`libpcsclite-dev`/pkg-config, so `--features hardware-proxy` cannot be
+*compiled* there (pcsc-sys needs the dev package). The protocol core,
+`VirtualCard`, and loopback test build and pass; the hardware backend is
+exercised on the wet-env machine.

--- a/docs/plans/2026-05-29-fibby-virtual-piv-rust-design.md
+++ b/docs/plans/2026-05-29-fibby-virtual-piv-rust-design.md
@@ -1,0 +1,375 @@
+---
+status: draft
+date: 2026-05-29
+provenance: |
+  Feasibility examination for `fibby`: a pure-Rust virtual PIV smart
+  card to replace (or sit beside) the current Java-based `fib`
+  (jCardSim + PivApplet + vsmartcard-vpcd + private pcscd). Drafted on
+  branch claude/virtual-piv-rust-EeB4T. Surveys prior art, fixes the
+  "no other dependencies" interpretation, sketches an architecture
+  anchored on the existing `piggy-piv` client and the Nitrokey
+  `vpicc-rs` transport, and lays out a spec/test-vector validation
+  strategy. Companion docs: docs/virtual-piv.md (current fib),
+  docs/rfcs/0002-piv-ecdh-box.md (piggy box wire format). Roadmap:
+  umbrella #3, triage #26, fib-limitation tracker #83.
+---
+
+# `fibby` — pure-Rust virtual PIV smart card (examination)
+
+## TL;DR
+
+A pure-Rust virtual PIV card is feasible and there is strong, directly
+reusable prior art. The honest framing of "no other dependencies" is
+**no Java / Maven / Oracle JavaCard SDK** — i.e. drop the jCardSim +
+PivApplet stack. The one C dependency that is impractical to remove in
+v1 is the PC/SC plumbing itself (`pcscd` + the `vsmartcard-vpcd`
+reader driver), because every piggy client (`pivy-tool`, `piggy
+agent`, `piggy-piv`) reaches a card through `libpcsclite` → `pcscd`.
+A second, fully-self-contained tier (reimplement the pcsc-lite IPC
+protocol so no `pcscd` runs at all) is possible but is a separate,
+larger effort and is **not** recommended for v1.
+
+Recommended shape:
+
+- A new `crates/fibby` binary that implements the PIV applet logic in
+  Rust and attaches to `pcscd` via the **`vpicc`** crate
+  (Nitrokey/vpicc-rs — the Rust port of the vsmartcard `vpcd`
+  protocol). This deletes the entire Java toolchain from the test
+  path while keeping the existing `vsmartcard-vpcd` + `pcscd` wiring
+  that `just fib-up` already manages.
+- Crypto via RustCrypto (`p256`, `p384`, `rsa`, `ed25519-dalek`,
+  `x25519-dalek`) — already in piggy's dependency closure.
+- Conformance is gated three ways: against piggy's own
+  **`piggy-piv`** client, against the C **`pivy-tool`**, and against
+  published NIST/Yubico **test vectors** plus RFC 0002 Appendix A.
+
+## Motivation
+
+`fib` (see `docs/virtual-piv.md`) is the software PIV card piggy's
+tests target instead of real hardware. It works, but the cost is
+steep:
+
+- **Heavy toolchain.** jCardSim is a Maven build that compiles
+  against the Oracle JavaCard SDK 3.0.5u3. We vendor the whole Maven
+  closure (`nix/jcardsim-m2/`) and carry an Oracle Binary Code License
+  note (`nix/virtual-piv.nix:14-24`) just to keep the build offline
+  and reproducible.
+- **Linux-only.** `vsmartcard` is marked broken on darwin, so fib
+  never runs on the macos-15 CI lane — the very lane that keeps
+  surprising us (see the `env -i` exit-126 note in CLAUDE.md, #100).
+- **Operationally fiddly.** A JVM, a TCP relay on port 35963, a
+  private `pcscd`, an INSTALL APDU, and a readiness probe
+  (`crates/fib-wait-ready`) all have to line up. The troubleshooting
+  section in `docs/virtual-piv.md` is long for a reason.
+- **Opaque to us.** When a crypto path misbehaves we are debugging
+  someone else's Java applet (`arekinath/PivApplet`) rather than code
+  we own and can instrument.
+
+A pure-Rust card we own would: build with `cargo` (no JVM/Maven/Oracle
+SDK), be debuggable in-tree, share types with `piggy-piv`, and — for
+the unit-test tier that does not need a real `pcscd` — run on darwin
+too.
+
+## Non-goals (v1)
+
+- **Not** a hardware replacement for the lifecycle/timing tests.
+  Card insert/remove events, touch-policy LED state, and genuine
+  Yubico factory attestation roots still need real hardware
+  (`*_hardware.bats`), exactly as today (`docs/virtual-piv.md:112`).
+- **Not** removing `pcscd`/`vsmartcard-vpcd` in v1. The
+  fully-self-contained "no daemon at all" tier is documented below as
+  a stretch goal, not a v1 deliverable.
+- **Not** a general-purpose JavaCard simulator. fibby virtualizes the
+  PIV applet (plus the YubiKey vendor extensions piggy uses), nothing
+  else.
+- **Not** a CAP file / on-hardware applet. fibby is host software.
+
+## Prior art
+
+### 1. `fib` — the incumbent (Java)
+
+`arekinath/jcardsim` (Java Card simulator) loads `arekinath/PivApplet`
+and exposes it over the vsmartcard `vpcd` TCP protocol. This is the
+baseline fibby replaces. It is also the **behavioural oracle**:
+fibby's command responses should match PivApplet's where piggy depends
+on them, because piggy's wire-format tests were calibrated against it.
+
+### 2. Nitrokey `vpicc-rs` + trussed `piv-authenticator` (the key find)
+
+There is already a **pure-Rust virtual PIV card** in the wild:
+
+- **`vpicc`** (crates.io, `Nitrokey/vpicc-rs`, MIT) — a Rust
+  implementation of the vsmartcard `vpcd` client side. You implement a
+  small trait (power on/off, reset, get-ATR, transmit-APDU) and it
+  handles the TCP framing to `pcscd`'s vpcd reader. This is exactly
+  the transport fibby needs, already in Rust. It means fibby does
+  **not** hand-roll the wire protocol.
+- **`trussed-dev/piv-authenticator`** (MIT/Apache) — a Rust
+  implementation of the PIV smartcard per NIST SP 800-73-4, built as a
+  Trussed app. Its own README states "nearly all functionality
+  specified by the standard [is] implemented." It is *tested using
+  `vpicc` + `opensc`/`pivy`-style clients*. This is the single most
+  reusable body of prior art: either depend on it, vendor it, or use
+  it as a reference implementation to crib the APDU dispatch from.
+
+The catch: `piv-authenticator` targets **Trussed** (the embedded HAL
+used by Nitrokey 3 / SoloKeys), so it pulls a `trussed` software
+backend and its crypto/storage abstractions. That is heavier than
+"no dependencies." Two ways to use it:
+
+- **(a) Reference only.** Read its APDU state machine and re-implement
+  a slimmer dispatcher directly on RustCrypto. Cleanest dependency
+  story, most work.
+- **(b) Depend on it behind `vpicc` + `trussed` software backend.**
+  Fastest path to a working card, but inherits the Trussed closure and
+  its PIV gaps (notably YubiKey vendor extensions — see below).
+
+### 3. vsmartcard / `vpcd` protocol (the transport spec)
+
+`vpcd` is a PC/SC reader driver (`libifdvpcd.so`) that `pcscd` loads;
+it relays APDUs over TCP (default port 35963 / `0x8C7B`) to a "vpicc"
+(virtual PICC = the card). The framing is trivial and fully public:
+
+- Each message is a **2-byte big-endian length prefix** followed by
+  that many payload bytes.
+- A **length-1** payload is a control byte: `0x00` power-off, `0x01`
+  power-on, `0x02` reset, `0x04` get-ATR. The card answers get-ATR
+  with its ATR bytes.
+- Any other payload is a **C-APDU**; the card answers with the
+  **R-APDU** (data ‖ SW1 SW2).
+
+`vpicc-rs` encapsulates all of this, so fibby implements the trait,
+not the framing. Our `nix/virtual-piv.nix` already builds the
+`vsmartcard-vpcd` driver and the matching `pcscd`; fibby reuses both
+unchanged.
+
+### 4. `yubikey.rs` (host side — not an emulator, but a spec mirror)
+
+`iqlusioninc/yubikey.rs` / `str4d/yubikey-piv.rs` are pure-Rust
+**host-side** PIV drivers. They don't emulate a card, but they encode,
+in Rust, exactly the YubiKey PIV command set, algorithm IDs, slot
+semantics, and the management-key/PIN/PUK flows. They are an excellent
+cross-check for "what does a real YubiKey expect on the wire," and
+their test fixtures are reusable.
+
+### 5. piggy's own `piggy-piv` (in-tree client + spec encoding)
+
+`crates/piggy-piv` is already a host-side PIV client and it pins the
+exact surface fibby must satisfy (see "Command surface" below). It is
+the *first* conformance client we should point at fibby because if
+fibby satisfies `piggy-piv`, piggy works.
+
+## What "no other dependencies" can mean — and the pcscd boundary
+
+The phrase has two defensible readings:
+
+1. **No Java/Maven/Oracle SDK** (drop jCardSim + PivApplet). Keep the
+   thin C plumbing (`pcscd` + `vsmartcard-vpcd`) that *every* PC/SC
+   client on the machine already needs. → **Recommended v1.**
+2. **No external runtime at all** — fibby is the only process; no
+   `pcscd`. This requires reimplementing the **pcsc-lite client IPC
+   protocol** (the `pcscd.comm` Unix-socket wire format that
+   `libpcsclite` speaks) so that `pivy-tool`/`piggy` connect straight
+   to fibby. That is a real, bounded protocol, but it is a second
+   project and it is brittle against libpcsclite version drift (we
+   already chase that — see the pcsclite 2.4.1 negotiation note in
+   `nix/virtual-piv.nix:148-166`). → **Stretch goal, separate issue.**
+
+For the **unit-test tier** there is a third, dependency-free reading
+that is genuinely zero-dep: fibby exposes a plain
+`transmit(&[u8]) -> Vec<u8>` function and tests drive it with raw
+APDUs, no PC/SC at all. This tier runs everywhere (including darwin)
+and is where the spec/test-vector validation lives. The `vpicc`
+transport is then just a thin adapter over that same core for the
+integration tier.
+
+```
+        ┌─────────────────────── crates/fibby ───────────────────────┐
+        │                                                             │
+unit ──▶│  Card core: APDU dispatch + state + RustCrypto  ◀── tests   │ (zero PC/SC, darwin-ok)
+        │            │                                                │
+        │            ▼                                                │
+integ ─▶│  vpicc adapter ──TCP 35963──▶ pcscd + vsmartcard-vpcd ──▶ pivy-tool / piggy
+        └─────────────────────────────────────────────────────────────┘
+```
+
+## Command surface fibby must implement (derived from piggy)
+
+This is the concrete, *minimum* set, read off `crates/piggy-piv`
+(`apdu.rs`, `token.rs`) and the `just fib-*` recipes — i.e. what piggy
+actually sends, not the whole of SP 800-73-4:
+
+| Command | INS | Why piggy needs it |
+|---|---|---|
+| SELECT (PIV AID `A0 00 00 03 08 00 00 10 00 01 00`) | `0xA4` | every session start; `fib-wait-ready` probes it |
+| GET DATA | `0xCB` | read CHUID + slot certs (recipients, attestation cert F9) |
+| PUT DATA | `0xDB` | import certs after `generate` |
+| VERIFY (PIN) | `0x20` | unlock before sign/ECDH |
+| CHANGE / RESET PIN, PUK | `0x24`/`0x2C` | PIN-management coverage |
+| GENERAL AUTHENTICATE | `0x87` | **the core**: sign (CHALLENGE→RESPONSE) and **ECDH** (EXPONENT→RESPONSE) — piggy box decrypt on slot 9D |
+| GENERATE ASYMMETRIC | `0x47` | `pivy-tool generate 9d` creates the test key |
+| GENERAL AUTHENTICATE (admin/3DES) | `0x87` | management-key auth before generate/put |
+| **YK attestation** | `0xF9` | `yk_attest` / `attest::parse_policy` (OID `1.3.6.1.4.1.41482.3.8`) |
+| **YK serial** | `0xF8` | `read_yk_serial` (vendor INS; `None` if unsupported) |
+| GET RESPONSE (chaining) | `0xC0` | long responses (RSA-2048 keys, cert reads) |
+
+Algorithms (`piggy-piv/src/apdu.rs::alg`, `slot.rs`): P-256 (`0x11`),
+P-384 (`0x14`), RSA-1024/2048 (`0x06`/`0x07`), and the YubicoPIV-5.7+
+proprietary Ed25519 (`0xE0`) / X25519 (`0xE1`). piggy's primary path
+is **P-256 ECDH in slot 9D** (Key Management) — that must be
+bit-exact, validated against RFC 0002 Appendix A.
+
+## Virtualizing "the most common YubiKey models"
+
+A "YubiKey model" from PIV's perspective is a *firmware version* plus
+*advertised capabilities*, not physically distinct silicon. fibby
+models this as a small config table:
+
+| Profile | Firmware | PIV traits that differ |
+|---|---|---|
+| YubiKey 4 / NEO | 4.x | RSA + ECC P-256/P-384; no AES mgmt key (3DES only); attestation from 4.3+ |
+| YubiKey 5 (pre-5.4.2) | 5.1–5.4 | adds touch/PIN policy; 3DES mgmt key |
+| YubiKey 5 (5.4.2+) | 5.4.2 | AES-192 management key default; CCC/CHUID |
+| YubiKey 5.7+ | 5.7 | adds Ed25519 (`0xE0`) / X25519 (`0xE1`) slots; RSA-3072/4096 |
+
+Concretely, fibby's YubiKey-ness is four things, all data not code:
+
+1. **AIDs.** Answer SELECT on both the PIV AID and the YubiKey
+   management AID `A0 00 00 05 27 47 11 17` (`apdu.rs::YKPIV_AID`).
+2. **Vendor INS.** Implement `0xF8` (serial) and `0xF9`
+   (attestation). A non-YubiKey profile simply rejects these with a
+   non-`9000` SW, which is exactly how piggy detects "no serial."
+3. **Attestation chain.** Emit a DER attestation cert carrying the
+   `1.3.6.1.4.1.41482.3.{8,9,10}` extensions (firmware/touch/PIN
+   policy) so `attest::parse_policy` works. Like PivApplet, fibby
+   signs with a **stub root**, not the genuine Yubico factory PKI —
+   real-root verification stays hardware-gated (documented limitation,
+   `docs/virtual-piv.md:115-118`).
+4. **ATR + firmware byte.** Return the right historical-bytes / ATR
+   and a `GET VERSION` (`0xFD`) firmware triple matching the chosen
+   profile.
+
+A `fibby --model yk5.7` flag (default to a 5.4.2-class profile) keeps
+this ergonomic.
+
+## Spec & test-vector validation strategy
+
+The user's ask — "validate as much as possible against public specs /
+RFCs and test vectors" — maps to four independent oracles:
+
+1. **NIST SP 800-73-4 (PIV card interface) + SP 800-78-4 (crypto algs).**
+   Drive the zero-PC/SC core with canonical APDU sequences from the
+   standard (SELECT, GET DATA object tags, GENERAL AUTHENTICATE
+   templates). These are structural, not secret-dependent, so they go
+   in `#[test]` modules with literal byte vectors.
+2. **RustCrypto known-answer tests.** ECDH (P-256/P-384) and the
+   Ed25519/X25519 paths are validated against the **Wycheproof** and
+   RFC 7748 / RFC 6979 / NIST CAVP vectors that RustCrypto already
+   ships — fibby reuses them so the card's crypto is provably correct
+   independent of PIV framing.
+3. **RFC 0002 Appendix A (piggy's own box vectors).** This is the
+   highest-value gate: `crates/piggy-box/src/piv_box.rs::tests::
+   rfc0002_vectors` already pins three bit-exact ECDH-box vectors. A
+   fibby integration test that seals to a fibby 9D key and round-trips
+   through `piggy box stream decrypt` exercises the *exact* path piggy
+   ships, and drift is already a CI failure by repo policy
+   (CLAUDE.md "Specs").
+4. **Differential vs C `pivy-tool` and real hardware.** Replay the
+   same APDU script against (a) fibby, (b) the incumbent Java `fib`,
+   and (c) a real YubiKey on the hardware lane; diff the R-APDUs. Any
+   divergence is either a fibby bug or a documented hardware-only
+   behaviour. `piggy-piv` is the in-tree client that makes this cheap.
+
+The layering means most validation runs in fast, hermetic `cargo
+test` (tiers 1–3); only tier 4's hardware leg needs the gated lane.
+
+## Proposed architecture
+
+```
+crates/fibby/
+  src/
+    main.rs        # CLI: --model, --port, --pin/--puk/--mgmt, --persist <file>
+    transport.rs   # vpicc adapter (impl vpicc::VSmartCard) — integration tier
+    core.rs        # transmit(&[u8]) -> Vec<u8>  — the zero-PC/SC entry point
+    dispatch.rs    # ISO 7816-4 APDU router (SELECT/GET DATA/GA/GENERATE/…)
+    state.rs       # card state: slots, PIN/PUK/retries, mgmt key, data objects
+    slots.rs       # 9A/9C/9D/9E + retired 82–95 + F9 attestation
+    crypto.rs      # RustCrypto: P-256/P-384 ECDH+ECDSA, RSA, Ed25519, X25519
+    yubikey.rs     # profiles, vendor INS 0xF8/0xF9/0xFD, attestation cert
+    atr.rs         # ATR + GET VERSION per profile
+  tests/
+    sp80073_vectors.rs   # tier 1
+    crypto_kat.rs        # tier 2
+    rfc0002_roundtrip.rs # tier 3 (gated where it needs pcscd)
+```
+
+Reuse, don't re-derive: `dispatch.rs`/`slots.rs` should share the TLV
+reader/writer, algorithm IDs, slot IDs, and GA template tags with
+`crates/piggy-piv` (move shared constants into a small common module
+so client and card can't drift). This is the same "shared substrate"
+discipline `store.rs`/`git_ops.rs` already follow.
+
+### Crate-vs-reuse decision (open)
+
+Whether to (a) write `dispatch.rs` fresh on RustCrypto or (b) depend
+on `trussed-dev/piv-authenticator` behind `vpicc` is the main
+architectural fork. Recommendation: **prototype with (b)** to get a
+card answering `pivy-tool list`/`generate` in days and learn the gaps,
+then decide whether the Trussed closure + its YubiKey-extension gaps
+justify the slimmer (a). The vendor extensions (`0xF8`/`0xF9`) are the
+likeliest thing `piv-authenticator` lacks, and they are exactly what
+piggy's attestation/serial paths need — so some custom code is
+probably unavoidable regardless.
+
+## Risks & open questions
+
+- **Trussed dependency weight (if we choose reuse).** `trussed` pulls
+  a crypto/storage HAL; "pure Rust" yes, "no other dependencies" not
+  really. Needs a call on which reading of the brief wins.
+- **YubiKey vendor extensions are under-specified.** `0xF8`/`0xF9` and
+  the attestation extension layout come from Yubico docs +
+  `yubico-piv-tool`/`pivy` source, not a NIST RFC. fibby must mirror
+  pivy's behaviour (`vendor/pivy/src/piv.c`) to stay compatible — this
+  is reverse-engineering, not spec-reading.
+- **Attestation root.** A stubbed chain (like PivApplet) means
+  genuine-root verification stays hardware-only. Acceptable, but must
+  be loudly documented so nobody mistakes a fibby attestation for a
+  real one (`piggy-test:`-style provenance applies here too).
+- **3DES management key.** Real YubiKeys still default to 3DES (or
+  AES-192 on 5.4.2+). RustCrypto's `des` is fine, but the GA
+  challenge-response mutual-auth flow needs care to match pivy.
+- **darwin reach.** The unit/core tier runs on darwin; the
+  `vpicc`+`pcscd` integration tier does not (same `vsmartcard`
+  brokenness as today). fibby narrows the gap (unit tier gains darwin)
+  but does not close it for the PC/SC integration tier.
+- **Self-contained tier (no pcscd).** Reimplementing the pcsc-lite
+  client IPC is the only way to make fibby *truly* dependency-free at
+  runtime; scope it as its own follow-up issue if/when desired.
+
+## Suggested phasing
+
+1. **Spike (reuse).** `crates/fibby` = `vpicc` + `piv-authenticator`
+   software backend. Goal: `just fib-up`-equivalent brings up a Rust
+   card; `pivy-tool -P 123456 -K default generate 9d` succeeds. Learn
+   the gaps. (No production claims yet.)
+2. **Core + tiers 1–3.** Zero-PC/SC `core::transmit`, SP 800-73-4
+   vectors, RustCrypto KATs, RFC 0002 round-trip. This is the part
+   that runs in plain `cargo test` on every platform.
+3. **YubiKey profiles.** Vendor INS `0xF8`/`0xF9`/`0xFD`, attestation
+   cert, model table, ATR/version. Validate `piggy-piv` attestation +
+   serial paths and the `recipients add --all-attached` flow (#83).
+4. **Swap the test path.** Add `just fibby-up`/`-down` mirroring the
+   fib recipes; flip the sandboxed bats lane and the `just
+   test-bats-conformance-*` recipes to fibby; keep `fib` available
+   behind a flag for one release as the differential oracle (tier 4).
+5. **(Stretch) self-contained.** Optional pcsc-lite IPC server so
+   fibby needs no `pcscd`. Separate issue.
+
+## Decision needed before implementation
+
+The "no other dependencies" brief and the Trussed-reuse question pull
+against each other. Before writing code we should pick: *slim/custom*
+(no Trussed, more work, cleanest deps) vs *reuse `piv-authenticator`*
+(fast, but inherits the Trussed closure and likely still needs custom
+YubiKey-extension code). The phasing above hedges by spiking on reuse
+first, but the production target should be chosen explicitly.

--- a/docs/plans/2026-05-29-fibby-virtual-piv-rust-design.md
+++ b/docs/plans/2026-05-29-fibby-virtual-piv-rust-design.md
@@ -373,3 +373,95 @@ against each other. Before writing code we should pick: *slim/custom*
 (fast, but inherits the Trussed closure and likely still needs custom
 YubiKey-extension code). The phasing above hedges by spiking on reuse
 first, but the production target should be chosen explicitly.
+
+---
+
+## Addendum (2026-05-29): chosen direction — reimplement pcscd + proxy-validate
+
+Direction set after the examination: **fibby implements the pcsc-lite
+*daemon* protocol itself** so clients connect straight to it with no
+`pcscd` and no `vsmartcard-vpcd`. This is the "fully self-contained"
+tier promoted from stretch goal to the goal, because the brief is to
+*decouple from pcscd and other nix-unfriendly C giants* — keeping
+`pcscd` would defeat that. Validation uses a **proxy pattern**: the
+same fibby server, backed by a hardware passthrough, drives a real
+YubiKey through the real `pcscd`, so we prove fibby's protocol layer
+against hardware before trusting the virtual card.
+
+### The pcsc-lite protocol (now grounded)
+
+Source of truth: LudovicRousseau/PCSC `src/winscard_msg.{h,c}`,
+**protocol 4.6**. Captured verbatim in `crates/fibby/src/proto.rs`:
+
+- **Framing.** `struct rxHeader { uint32_t size; uint32_t command; }`
+  (8 bytes) then a `size`-byte body. Native host byte order, natural
+  alignment, no packing — and every field we touch is 4-byte-aligned,
+  so a packed little-endian codec is bit-identical on x86-64/aarch64
+  (asserted at the codec boundary, not assumed).
+- **Commands** (`enum pcsc_msg_commands`): `SCARD_ESTABLISH_CONTEXT`
+  0x01 … `SCARD_TRANSMIT` 0x09 … `CMD_VERSION` 0x11 …
+  `CMD_GET_READERS_STATE_ARRAY` 0x17.
+- **Handshake.** Client sends `CMD_VERSION` with
+  `version_struct{major,minor,rv}`; fibby must answer with a matching
+  major or the client aborts with `SCARD_E_SERVICE_STOPPED` (the *only*
+  cause of that error per Rousseau's FAQ).
+- **Per-command bodies.** `establish_struct`, `connect_struct`
+  (carries `szReader[128]`), `transmit_struct` (32-byte fixed header
+  then streamed APDU buffers), `disconnect_struct`, `status_struct`,
+  the reader-state array, etc. — all mirrored in `proto.rs`.
+
+### Architecture: one server, swappable backend
+
+```
+client (pivy-tool / piggy / opensc-tool)
+   │  PCSCLITE_CSOCK_NAME → fibby's Unix socket
+   ▼
+crates/fibby  ── pcsc-lite daemon protocol (proto.rs) ──┐
+                                                        │ Backend trait
+            ┌───────────────────────────────────────────┤
+            ▼                                            ▼
+  HardwareProxy (feature "hardware-proxy")        VirtualCard
+  forwards via the `pcsc` crate to the real        the in-Rust PIV
+  pcscd → real YubiKey  [VALIDATION ORACLE]        applet  [THE GOAL]
+```
+
+The proxy and the virtual card share **one** server implementation, so
+proving the protocol layer against hardware (HardwareProxy) directly
+de-risks the virtual path (VirtualCard). The hardware backend is behind
+the `hardware-proxy` Cargo feature so the protocol core + virtual card
+build and unit-test on hosts with no PCSC headers (CI containers,
+darwin).
+
+### Environment constraint
+
+The web/cloud session container has `libpcsclite.so.1` at runtime but
+**no pcscd, no USB, no reader, and no PCSC headers**. Therefore:
+
+- **Buildable + unit-testable here:** `proto.rs` codec, the server
+  state machine, the `VirtualCard` backend, byte-vector conformance.
+- **Runs only on a machine with a YubiKey:** the `HardwareProxy`
+  backend and the end-to-end proxy validation. That leg is operator-
+  driven (`cargo run -p fibby --features hardware-proxy`).
+
+### Landed in this pass
+
+- `crates/fibby` added to the workspace.
+- `proto.rs`: protocol constants (v4.6), the full `Command` enum with
+  wire values, and codecs for `rxHeader`, `version_struct`,
+  `establish_struct`, `transmit_struct`, plus a little-endian-host
+  assertion. 6 unit tests, all green (`cargo test -p fibby
+  --no-default-features`).
+
+### Next steps
+
+1. Flesh out the remaining `*_struct` codecs (connect/reconnect/
+   disconnect/status/get-status-change + the `READER_STATE` array).
+2. Server event loop: Unix-socket listener, `CMD_VERSION` handshake,
+   context/card handle table, command dispatch to a `Backend`.
+3. `Backend` trait + `HardwareProxy` (via `pcsc` crate) + a stub
+   `VirtualCard` (fixed ATR, SELECT echo).
+4. **Capture/validate:** point `pivy-tool list`/`generate 9d` at fibby
+   with the HardwareProxy backend on a machine with a YubiKey; record
+   the wire traffic as conformance fixtures.
+5. Grow `VirtualCard` into the real PIV applet (phases 2–3 above) and
+   replay the captured fixtures against it.


### PR DESCRIPTION
Adds a new `crates/fibby` crate that implements the pcsc-lite daemon
protocol (`pcscd.comm`) in Rust, plus a virtual-PIV and a hardware-proxy
backend behind it. Clients (pivy-tool, piggy, opensc-tool) connect via
`PCSCLITE_CSOCK_NAME` with no system pcscd and no vsmartcard-vpcd. Once
`VirtualCard` grows the PIV applet, this replaces the Java fib stack
(jCardSim + PivApplet + vsmartcard-vpcd).

Umbrella #3 / triage #26 / fib-limitation tracker #83.
Design doc: `docs/plans/2026-05-29-fibby-virtual-piv-rust-design.md`.

## What's landed

- **Design doc** — prior-art survey (Nitrokey vpicc-rs,
  trussed-dev/piv-authenticator, yubikey.rs), command-surface derived
  from `piggy-piv`, and the four-oracle validation strategy (SP
  800-73-4 / RustCrypto KATs / RFC 0002 Appendix A / differential vs
  C pivy-tool + hardware).
- **Protocol layer** (`proto.rs`, `frame.rs`, `error.rs`, `trace.rs`)
  — pcsc-lite protocol 4.6 codec, message framing with streamed
  TRANSMIT payloads, `SCARD_*` codes, `FIBBY_LOG`-gated tracing.
- **Backends** (`backend.rs`, `virtual_card.rs`, `hardware_proxy.rs`)
  — `Backend` trait + stub PIV card (SELECT → 9000, else 6D00) +
  real-pcscd proxy (feature `hardware-proxy`).
- **Server** (`server.rs`, `main.rs`) — listen loop, `CMD_VERSION`
  handshake, dispatch for the full common command set; unimplemented
  commands log loudly and close (no silent mis-replies). CLI
  (`--socket` / `--backend` / `--reader`).
- **Tests** — 17 codec/framing/virtual-card units +
  `tests/loopback.rs` (full PC/SC session over a real Unix socket
  against `VirtualCard`).
- **`README.md`** — module map, `FIBBY_LOG` guide, hardware-validation
  runbook.

## Host-devshell unblock (last two commits)

The crate was first assembled in a container with no PCSC headers and
a short `$TMPDIR`. Three blockers surfaced on a real devshell:

- `--features hardware-proxy` failed against `pcsc` 2.9:
  `Card::status2` takes two buffers (names + ATR), not one;
  `CardStatus::protocol2()` returns `Option<Protocol>`. Both call
  sites fixed.
- `clippy::assertions_on_constants` tripped on `assert_le_host`
  (gated by `just lint-rust` `-D warnings` — the
  `merge-this-session` pre-merge hook). Wrapped the assert in
  `const { ... }`. Same loudness on big-endian, no runtime cost.
- `tests/loopback.rs` silently relied on a short `$TMPDIR`. Under
  spinclass worktrees (`<repo>/.worktrees/<name>/.tmp/`), the AF_UNIX
  `sun_path` 108-byte limit overflows and `bind()` fails in the
  detached server thread with no error visible to the test. Pinned
  the socket under `/tmp` (short + writable in host devshell, nix
  sandbox's private /tmp, and GitHub Actions).

Verified: `cargo test -p fibby`, full workspace clippy,
`cargo build -p fibby --features hardware-proxy`, and the same clippy
with the feature all pass on host devshell.

## Next steps (not in this PR)

Wet-env / cross-cutting follow-ups, tracked separately under #26.

1. **Hardware validation pass** — the point of the now-compiling
   `hardware-proxy` backend. Per the README runbook: on a machine
   with a YubiKey, build with the feature, point `pivy-tool list`
   and `pivy-tool -P 123456 -K default generate 9d` at fibby's socket
   through the real card, capture `FIBBY_LOG=wire` traffic as the
   conformance fixture for `VirtualCard`. Confirms the spec-flagged
   assumptions: `ReaderState` 184-byte layout / 3-byte ATR padding,
   `server::wait_reader_state` static-card timeout semantics,
   `server::status` carrying only hCard+rv, `YUBIKEY5_ATR`,
   `pcsc::Error → SCARD_*` mapping. Then drive `piggy` itself through
   fibby (tier-4 differential gate).

2. **Flesh out `VirtualCard`** — the real PIV applet: GENERATE,
   GENERAL AUTHENTICATE (sign + ECDH on slot 9D), GET/PUT DATA,
   VERIFY, YubiKey attestation (`0xF9`) + serial (`0xF8`). Validate
   against the captured wet-env fixtures + RFC 0002 Appendix A
   vectors + SP 800-73-4 / Wycheproof KATs.

3. **Nix integration** — `flake.nix` doesn't yet expose `fibby` as a
   package; add `packages.fibby` (linux-only for hardware-proxy
   linkage) and a `just fibby-up` / `fibby-down` recipe pair
   mirroring the fib recipes. Then swap the sandboxed bats lane and
   `just test-bats-conformance-*` recipes onto fibby, keeping the
   Java `fib` as the differential oracle for one release.

4. **Stretch** — `--model {yk4,yk5,yk5.7}` profile flag, YubiKey
   attestation cert with stub root (loudly labeled as fibby's, not
   Yubico's), 3DES/AES-192 mgmt-key challenge-response, hot-plug
   events via `SCardGetStatusChange`.

---

🤡 Co-authored with [Clown](https://github.com/amarbel-llc/clown).